### PR TITLE
Performance overhaul

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,6 +20,7 @@ return (new Config())
 		Finder::create()
 			->in(__DIR__)
 			->exclude([
+				'bin',
 				'templates',
 				'tests/fixtures',
 			])

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $rewrites = (new \ToyWpRouting\RouteConverter())->convertCollection($routes);
 ```
 
 ## Caching
-Whether you are using rewrites or routes, it is recommended to enable rewrite caching.
+If you have opcache enabled, you may see improved performance by enabling rewrite caching.
 
 ```php
 $cache = new \ToyWpRouting\RewriteCollectionCache(__DIR__ . '/var/cache');
@@ -95,7 +95,7 @@ if ($cache->exists()) {
 (new \ToyWpRouting\Orchestrator($rewrites))->initialize();
 ```
 
-Caching is not automatic - You might want to use something like WP-CLI to manage the cache.
+Caching is not automatic - You will want to use something like WP-CLI to manage the cache.
 
 Use `RewriteCollectionCache->put(RewriteCollection)` to cache rewrites. Existing cache will be
 overwritten.
@@ -129,3 +129,7 @@ $orchestrator->getInvocationStrategy()->setCallableResolver(function ($potential
 
 $orchestrator->initialize();
 ```
+
+Please note that if opcache is not enabled performance will likely suffer by using the rewrite cache.
+
+That said - It is always best to perform some sort of profiling on a case-by-case base in order to determine what is best for your specific environment.

--- a/bin/regenerate-test-fixtures.php
+++ b/bin/regenerate-test-fixtures.php
@@ -1,0 +1,24 @@
+#!/usr/bin/env php
+<?php
+
+use ToyWpRouting\RewriteCollection;
+use ToyWpRouting\RewriteCollectionCache;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// Regular
+$rewriteCollection = new RewriteCollection();
+
+$rewriteCollection->get('^first$', 'index.php?var=first', 'firsthandler');
+$rewriteCollection->post('^second$', 'index.php?var=second', 'secondhandler')->setIsActiveCallback('secondisactivecallback');
+
+$rewriteCollectionCache = new RewriteCollectionCache(__DIR__ . '/../tests/fixtures', 'rewrite-cache.php');
+$rewriteCollectionCache->put($rewriteCollection);
+
+// Closures
+$rewriteCollection = new RewriteCollection('pfx_');
+
+$rewriteCollection->get('^regex$', 'index.php?var=val', function () {})->setIsActiveCallback(function () {});
+
+$rewriteCollectionCache = new RewriteCollectionCache(__DIR__ . '/../tests/fixtures', 'rewrite-cache-serialized-closures.php');
+$rewriteCollectionCache->put($rewriteCollection);

--- a/src/AbstractInvocationStrategy.php
+++ b/src/AbstractInvocationStrategy.php
@@ -69,9 +69,9 @@ abstract class AbstractInvocationStrategy implements InvocationStrategyInterface
         // @todo Test with optional params.
         // @todo Include all query vars?
         // @todo Include prefixed query vars as well?
-        foreach ($rewrite->getPrefixedToUnprefixedQueryVariablesMap() as $prefixed => $unprefixed) {
-            if (array_key_exists($prefixed, $this->context['queryVars'])) {
-                $resolved[$unprefixed] = $this->context['queryVars'][$prefixed];
+        foreach ($this->context['queryVars'] as $key => $value) {
+            if (is_string($newKey = $rewrite->mapQueryVariable($key))) {
+                $resolved[$newKey] = $value;
             }
         }
 

--- a/src/Compiler/OptimizedRewrite.php
+++ b/src/Compiler/OptimizedRewrite.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting;
+namespace ToyWpRouting\Compiler;
 
 use RuntimeException;
+use ToyWpRouting\InvocationStrategyInterface;
+use ToyWpRouting\Rewrite;
 
 class OptimizedRewrite extends Rewrite
 {

--- a/src/Compiler/OptimizedRewriteRule.php
+++ b/src/Compiler/OptimizedRewriteRule.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting;
+namespace ToyWpRouting\Compiler;
+
+use ToyWpRouting\RewriteRuleInterface;
 
 class OptimizedRewriteRule implements RewriteRuleInterface
 {

--- a/src/Compiler/RewriteCompiler.php
+++ b/src/Compiler/RewriteCompiler.php
@@ -10,7 +10,7 @@ use ToyWpRouting\RewriteInterface;
 
 class RewriteCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewrite(%s, %s, %s, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewrite(%s, %s, %s, $this->invocationStrategy, %s, %s)';
 
     private RewriteInterface $rewrite;
 

--- a/src/Compiler/RewriteCompiler.php
+++ b/src/Compiler/RewriteCompiler.php
@@ -10,7 +10,7 @@ use ToyWpRouting\RewriteInterface;
 
 class RewriteCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewrite(%s, %s, %s, $this->invocationStrategy, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\Compiler\\OptimizedRewrite(%s, %s, %s, $this->invocationStrategy, %s, %s)';
 
     private RewriteInterface $rewrite;
 

--- a/src/Compiler/RewriteCompiler.php
+++ b/src/Compiler/RewriteCompiler.php
@@ -10,7 +10,7 @@ use ToyWpRouting\RewriteInterface;
 
 class RewriteCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewrite(%s, %s, %s, %s, %s, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewrite(%s, %s, %s, %s, %s)';
 
     private RewriteInterface $rewrite;
 
@@ -29,11 +29,9 @@ class RewriteCompiler
         return sprintf(
             self::TEMPLATE,
             $this->methods(),
-            $this->rewriteRules(),
             $this->rules(),
-            $this->handler(),
-            $this->prefixedToUnprefixedQueryVariablesMap(),
             $this->queryVariables(),
+            $this->handler(),
             $this->isActiveCallback()
         );
     }
@@ -80,19 +78,17 @@ class RewriteCompiler
         return var_export($this->rewrite->getMethods(), true);
     }
 
-    private function prefixedToUnprefixedQueryVariablesMap(): string
-    {
-        return var_export($this->rewrite->getPrefixedToUnprefixedQueryVariablesMap(), true);
-    }
-
     private function queryVariables(): string
     {
-        return var_export($this->rewrite->getQueryVariables(), true);
-    }
+        $queryVariables = [];
 
-    private function rewriteRules(): string
-    {
-        return var_export($this->rewrite->getRewriteRules(), true);
+        foreach ($this->rewrite->getRules() as $rule) {
+            foreach ($rule->getQueryVariables() as $prefixed => $unprefixed) {
+                $queryVariables[$prefixed] = $unprefixed;
+            }
+        }
+
+        return var_export($queryVariables, true);
     }
 
     private function rules(): string

--- a/src/Compiler/RewriteListDefinitionsCompiler.php
+++ b/src/Compiler/RewriteListDefinitionsCompiler.php
@@ -34,8 +34,8 @@ class RewriteListDefinitionsCompiler
     private function prepareTemplate(): string
     {
         return implode(PHP_EOL, array_map(
-            fn ($n) => "\$rewrite{$n} = %s;" . PHP_EOL . "\$this->rewrites->attach(\$rewrite{$n});",
-            range(0, count($this->rewrites) - 1)
+            fn ($_) => '$this->rewrites->attach(%s);',
+            $this->rewrites
         ));
     }
 }

--- a/src/Compiler/RewriteRuleCompiler.php
+++ b/src/Compiler/RewriteRuleCompiler.php
@@ -8,7 +8,7 @@ use ToyWpRouting\RewriteRuleInterface;
 
 class RewriteRuleCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewriteRule(%s, %s, %s, %s, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewriteRule(%s, %s, %s, %s)';
 
     private RewriteRuleInterface $rule;
 
@@ -27,9 +27,7 @@ class RewriteRuleCompiler
         return sprintf(
             self::TEMPLATE,
             $this->hash(),
-            $this->prefixedQueryArray(),
             $this->query(),
-            $this->queryArray(),
             $this->queryVariables(),
             $this->regex()
         );
@@ -40,19 +38,9 @@ class RewriteRuleCompiler
         return var_export($this->rule->getHash(), true);
     }
 
-    private function prefixedQueryArray(): string
-    {
-        return var_export($this->rule->getPrefixedQueryArray(), true);
-    }
-
     private function query(): string
     {
         return var_export($this->rule->getQuery(), true);
-    }
-
-    private function queryArray(): string
-    {
-        return var_export($this->rule->getQueryArray(), true);
     }
 
     private function queryVariables(): string

--- a/src/Compiler/RewriteRuleCompiler.php
+++ b/src/Compiler/RewriteRuleCompiler.php
@@ -8,7 +8,7 @@ use ToyWpRouting\RewriteRuleInterface;
 
 class RewriteRuleCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewriteRule(%s, %s, %s, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewriteRule(%s, %s, %s, %s, %s, %s)';
 
     private RewriteRuleInterface $rule;
 
@@ -30,6 +30,7 @@ class RewriteRuleCompiler
             $this->prefixedQueryArray(),
             $this->query(),
             $this->queryArray(),
+            $this->queryVariables(),
             $this->regex()
         );
     }
@@ -52,6 +53,11 @@ class RewriteRuleCompiler
     private function queryArray(): string
     {
         return var_export($this->rule->getQueryArray(), true);
+    }
+
+    private function queryVariables(): string
+    {
+        return var_export($this->rule->getQueryVariables(), true);
     }
 
     private function regex(): string

--- a/src/Compiler/RewriteRuleCompiler.php
+++ b/src/Compiler/RewriteRuleCompiler.php
@@ -8,7 +8,7 @@ use ToyWpRouting\RewriteRuleInterface;
 
 class RewriteRuleCompiler
 {
-    private const TEMPLATE = 'new \\ToyWpRouting\\OptimizedRewriteRule(%s, %s, %s, %s)';
+    private const TEMPLATE = 'new \\ToyWpRouting\\Compiler\\OptimizedRewriteRule(%s, %s, %s, %s)';
 
     private RewriteRuleInterface $rule;
 

--- a/src/OptimizedRewrite.php
+++ b/src/OptimizedRewrite.php
@@ -17,17 +17,26 @@ class OptimizedRewrite extends Rewrite
         array $methods,
         array $rules,
         array $queryVariables,
+        InvocationStrategyInterface $invocationStrategy,
         $handler,
         $isActiveCallback = null
     ) {
         parent::__construct($methods, $rules, $handler, $isActiveCallback);
 
         $this->queryVariables = $queryVariables;
+        $this->invocationStrategy = $invocationStrategy;
     }
 
     public function mapQueryVariable(string $queryVariable): ?string
     {
         return $this->queryVariables[$queryVariable] ?? null;
+    }
+
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): Rewrite
+    {
+        throw new RuntimeException(
+            'Cannot override invocationStrategy on OptimizedRewrite instance'
+        );
     }
 
     public function setIsActiveCallback($isActiveCallback): Rewrite

--- a/src/OptimizedRewrite.php
+++ b/src/OptimizedRewrite.php
@@ -4,123 +4,34 @@ declare(strict_types=1);
 
 namespace ToyWpRouting;
 
-class OptimizedRewrite implements RewriteInterface
+use RuntimeException;
+
+class OptimizedRewrite extends Rewrite
 {
     /**
-     * @var mixed
-     */
-    protected $handler;
-
-    /**
-     * @var mixed
-     */
-    protected $isActiveCallback;
-
-    /**
-     * @var array<int, "GET"|"HEAD"|"POST"|"PUT"|"PATCH"|"DELETE"|"OPTIONS">
-     */
-    protected array $methods;
-
-    /**
      * @var array<string, string>
-     */
-    protected array $prefixedToUnprefixedQueryVariablesMap;
-
-    /**
-     * @var string[]
      */
     protected array $queryVariables;
 
-    /**
-     * @var array<string, string>
-     */
-    protected array $rewriteRules;
-
-    /**
-     * @var RewriteRuleInterface[]
-     */
-    protected array $rules;
-
-    /**
-     * @param array<int, "GET"|"HEAD"|"POST"|"PUT"|"PATCH"|"DELETE"|"OPTIONS"> $methods
-     * @param array<string, string> $rewriteRules
-     * @param RewriteRuleInterface[] $rules
-     * @param mixed $handler
-     * @param array<string, string> $prefixedToUnprefixedQueryVariablesMap
-     * @param string[] $queryVariables
-     * @param mixed $isActiveCallback
-     */
     public function __construct(
         array $methods,
-        array $rewriteRules,
         array $rules,
-        $handler,
-        array $prefixedToUnprefixedQueryVariablesMap,
         array $queryVariables,
+        $handler,
         $isActiveCallback = null
     ) {
-        $this->methods = $methods;
-        $this->rewriteRules = $rewriteRules;
-        $this->rules = $rules;
-        $this->handler = $handler;
-        $this->prefixedToUnprefixedQueryVariablesMap = $prefixedToUnprefixedQueryVariablesMap;
+        parent::__construct($methods, $rules, $handler, $isActiveCallback);
+
         $this->queryVariables = $queryVariables;
-        $this->isActiveCallback = $isActiveCallback;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getHandler()
+    public function mapQueryVariable(string $queryVariable): ?string
     {
-        return $this->handler;
+        return $this->queryVariables[$queryVariable] ?? null;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getIsActiveCallback()
+    public function setIsActiveCallback($isActiveCallback): Rewrite
     {
-        return $this->isActiveCallback;
-    }
-
-    /**
-     * @return array<int, "GET"|"HEAD"|"POST"|"PUT"|"PATCH"|"DELETE"|"OPTIONS">
-     */
-    public function getMethods(): array
-    {
-        return $this->methods;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getPrefixedToUnprefixedQueryVariablesMap(): array
-    {
-        return $this->prefixedToUnprefixedQueryVariablesMap;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getQueryVariables(): array
-    {
-        return $this->queryVariables;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getRewriteRules(): array
-    {
-        return $this->rewriteRules;
-    }
-
-    /**
-     * @return RewriteRuleInterface[]
-     */
-    public function getRules(): array
-    {
-        return $this->rules;
+        throw new RuntimeException('Cannot override isActiveCallback on OptimizedRewrite instance');
     }
 }

--- a/src/OptimizedRewriteRule.php
+++ b/src/OptimizedRewriteRule.php
@@ -9,17 +9,7 @@ class OptimizedRewriteRule implements RewriteRuleInterface
 {
     protected string $hash;
 
-    /**
-     * @var array<string, string>
-     */
-    protected array $prefixedQueryArray;
-
     protected string $query;
-
-    /**
-     * @var array<string, string>
-     */
-    protected array $queryArray;
 
     /**
      * @var array<string, string>
@@ -29,22 +19,16 @@ class OptimizedRewriteRule implements RewriteRuleInterface
     protected string $regex;
 
     /**
-     * @param array<string, string> $prefixedQueryArray
-     * @param array<string, string> $queryArray
      * @param array<string, string> $queryVariables
      */
     public function __construct(
         string $hash,
-        array $prefixedQueryArray,
         string $query,
-        array $queryArray,
         array $queryVariables,
         string $regex
     ) {
         $this->hash = $hash;
-        $this->prefixedQueryArray = $prefixedQueryArray;
         $this->query = $query;
-        $this->queryArray = $queryArray;
         $this->queryVariables = $queryVariables;
         $this->regex = $regex;
     }
@@ -54,25 +38,9 @@ class OptimizedRewriteRule implements RewriteRuleInterface
         return $this->hash;
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function getPrefixedQueryArray(): array
-    {
-        return $this->prefixedQueryArray;
-    }
-
     public function getQuery(): string
     {
         return $this->query;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getQueryArray(): array
-    {
-        return $this->queryArray;
     }
 
     public function getQueryVariables(): array

--- a/src/OptimizedRewriteRule.php
+++ b/src/OptimizedRewriteRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ToyWpRouting;
 
-// @todo Tests?
 class OptimizedRewriteRule implements RewriteRuleInterface
 {
     protected string $hash;

--- a/src/OptimizedRewriteRule.php
+++ b/src/OptimizedRewriteRule.php
@@ -21,23 +21,31 @@ class OptimizedRewriteRule implements RewriteRuleInterface
      */
     protected array $queryArray;
 
+    /**
+     * @var array<string, string>
+     */
+    protected array $queryVariables;
+
     protected string $regex;
 
     /**
      * @param array<string, string> $prefixedQueryArray
      * @param array<string, string> $queryArray
+     * @param array<string, string> $queryVariables
      */
     public function __construct(
         string $hash,
         array $prefixedQueryArray,
         string $query,
         array $queryArray,
+        array $queryVariables,
         string $regex
     ) {
         $this->hash = $hash;
         $this->prefixedQueryArray = $prefixedQueryArray;
         $this->query = $query;
         $this->queryArray = $queryArray;
+        $this->queryVariables = $queryVariables;
         $this->regex = $regex;
     }
 
@@ -65,6 +73,11 @@ class OptimizedRewriteRule implements RewriteRuleInterface
     public function getQueryArray(): array
     {
         return $this->queryArray;
+    }
+
+    public function getQueryVariables(): array
+    {
+        return $this->queryVariables;
     }
 
     public function getRegex(): string

--- a/src/Orchestrator.php
+++ b/src/Orchestrator.php
@@ -19,7 +19,6 @@ class Orchestrator
         RewriteCollection $rewriteCollection,
         ?RequestContext $requestContext = null
     ) {
-        // @todo accept invoker and have factory methods for rewrite and route collections, cache, etc?
         $this->requestContext = $requestContext;
         $this->rewriteCollection = $rewriteCollection;
     }
@@ -114,27 +113,12 @@ class Orchestrator
             return;
         }
 
-        $hasMatchedRule = false;
-        $matchedRuleKey = null;
+        $matchedRuleKey = "{$this->rewriteCollection->getPrefix()}matchedRule";
 
-        foreach ($queryVars as $key => $_) {
-            if ('matchedRule' === substr($key, -11)) {
-                $hasMatchedRule = true;
-                $matchedRuleKey = $key;
-                break;
-            }
-        }
-
-        if (! $hasMatchedRule) {
+        if (! array_key_exists($matchedRuleKey, $queryVars)) {
             return;
         }
 
-        /**
-         * @psalm-suppress PossiblyNullArrayOffset
-         * @todo The logic above for determining matched rule key can be refactored now that we have
-         *       introduced the RewriteCollection->getPrefix() method. Or better yet, we should
-         *       probably refactor to use $wp->matched_rule instead of a query variable.
-         */
         if (! is_string($queryVars[$matchedRuleKey])) {
             return;
         }

--- a/src/Rewrite.php
+++ b/src/Rewrite.php
@@ -14,6 +14,11 @@ class Rewrite implements RewriteInterface
     protected $handler;
 
     /**
+     * @var InvocationStrategyInterface
+     */
+    protected $invocationStrategy;
+
+    /**
      * @var mixed
      */
     protected $isActiveCallback;
@@ -53,6 +58,15 @@ class Rewrite implements RewriteInterface
         return $this->handler;
     }
 
+    public function getInvocationStrategy()
+    {
+        if (! $this->invocationStrategy instanceof InvocationStrategyInterface) {
+            $this->invocationStrategy = new DefaultInvocationStrategy();
+        }
+
+        return $this->invocationStrategy;
+    }
+
     /**
      * @return mixed
      */
@@ -77,6 +91,18 @@ class Rewrite implements RewriteInterface
         return $this->rules;
     }
 
+    public function handle(array $queryVariables = [])
+    {
+        return $this->getInvocationStrategy()
+            ->withAdditionalContext(['queryVars' => $queryVariables])
+            ->invokeHandler($this);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->getInvocationStrategy()->invokeIsActiveCallback($this);
+    }
+
     public function mapQueryVariable(string $queryVariable): ?string
     {
         foreach ($this->rules as $rule) {
@@ -88,6 +114,13 @@ class Rewrite implements RewriteInterface
         }
 
         return null;
+    }
+
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): self
+    {
+        $this->invocationStrategy = $invocationStrategy;
+
+        return $this;
     }
 
     /**

--- a/src/Rewrite.php
+++ b/src/Rewrite.php
@@ -130,18 +130,7 @@ class Rewrite implements RewriteInterface
             // @todo Eliminate rewrite rules at this level? Handled by rewrite collection.
             $this->rewriteRules[$rule->getRegex()] = $rule->getQuery();
 
-            $prefixedQueryVariables = array_keys($rule->getPrefixedQueryArray());
-            $queryVariables = array_keys($rule->getQueryArray());
-
-            $count = count($queryVariables);
-
-            // @todo ???
-            // assert(count($queryVariables) === count($prefixedQueryVariables));
-
-            // @todo array_combine()??
-            for ($i = 0; $i < $count; $i++) {
-                $this->queryVariables[$prefixedQueryVariables[$i]] = $queryVariables[$i];
-            }
+            $this->queryVariables = array_merge($this->queryVariables, $rule->getQueryVariables());
         }
     }
 }

--- a/src/RewriteCollection.php
+++ b/src/RewriteCollection.php
@@ -146,18 +146,6 @@ class RewriteCollection
     /**
      * @return array<string, string>
      */
-    public function getPrefixedToUnprefixedQueryVariablesMap(): array
-    {
-        if (null === $this->activeQueryVariables) {
-            $this->prepareComputedProperties();
-        }
-
-        return $this->activeQueryVariables;
-    }
-
-    /**
-     * @return array<string, string>
-     */
     public function getRewriteRules(): array
     {
         if (null === $this->rewriteRules) {

--- a/src/RewriteCollection.php
+++ b/src/RewriteCollection.php
@@ -48,14 +48,13 @@ class RewriteCollection
 
         $this->rewrites->attach($rewrite);
 
-        //  @todo Minimize loopage?
-        $this->rewriteRules = array_merge($this->rewriteRules, $rewrite->getRewriteRules());
-        $this->queryVariables = array_merge(
-            $this->queryVariables,
-            $rewrite->getPrefixedToUnprefixedQueryVariablesMap()
-        );
-
         foreach ($rewrite->getRules() as $rule) {
+            $this->rewriteRules[$rule->getRegex()] = $rule->getQuery();
+
+            foreach ($rule->getQueryVariables() as $prefixed => $unprefixed) {
+                $this->queryVariables[$prefixed] = $unprefixed;
+            }
+
             $hash = $rule->getHash();
 
             if (! array_key_exists($hash, $this->rewritesByRegexHashAndMethod)) {

--- a/src/RewriteCollectionCache.php
+++ b/src/RewriteCollectionCache.php
@@ -40,7 +40,7 @@ class RewriteCollectionCache
 
     public function get(): RewriteCollection
     {
-        $factory = static::staticInclude("{$this->dir}/{$this->file}");
+        $factory = (static fn ($dir, $file) => include "{$dir}/{$file}")($this->dir, $this->file);
 
         return $factory($this->getInvocationStrategy());
     }
@@ -69,13 +69,5 @@ class RewriteCollectionCache
         $this->invocationStrategy = $invocationStrategy;
 
         return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    protected static function staticInclude(string $file)
-    {
-        return include $file;
     }
 }

--- a/src/RewriteCollectionCache.php
+++ b/src/RewriteCollectionCache.php
@@ -12,10 +12,16 @@ class RewriteCollectionCache
 
     protected string $file;
 
-    public function __construct(string $dir, string $file = 'rewrite-cache.php')
-    {
+    protected InvocationStrategyInterface $invocationStrategy;
+
+    public function __construct(
+        string $dir,
+        string $file = 'rewrite-cache.php',
+        ?InvocationStrategyInterface $invocationStrategy = null
+    ) {
         $this->dir = $dir;
         $this->file = $file;
+        $this->invocationStrategy = $invocationStrategy ?: new DefaultInvocationStrategy();
     }
 
     public function delete(): void
@@ -34,7 +40,14 @@ class RewriteCollectionCache
 
     public function get(): RewriteCollection
     {
-        return static::staticInclude("{$this->dir}/{$this->file}");
+        $factory = static::staticInclude("{$this->dir}/{$this->file}");
+
+        return $factory($this->getInvocationStrategy());
+    }
+
+    public function getInvocationStrategy(): InvocationStrategyInterface
+    {
+        return $this->invocationStrategy;
     }
 
     public function put(RewriteCollection $rewriteCollection): void
@@ -49,6 +62,13 @@ class RewriteCollectionCache
         $compiled = (string) (new RewriteCollectionCompiler($rewriteCollection));
 
         file_put_contents("{$this->dir}/{$this->file}", $compiled);
+    }
+
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): self
+    {
+        $this->invocationStrategy = $invocationStrategy;
+
+        return $this;
     }
 
     /**

--- a/src/RewriteInterface.php
+++ b/src/RewriteInterface.php
@@ -22,22 +22,9 @@ interface RewriteInterface
     public function getMethods(): array;
 
     /**
-     * @return array<string, string>
-     */
-    public function getPrefixedToUnprefixedQueryVariablesMap(): array;
-
-    /**
-     * @return string[]
-     */
-    public function getQueryVariables(): array;
-
-    /**
-     * @return array<string, string>
-     */
-    public function getRewriteRules(): array;
-
-    /**
      * @return RewriteRuleInterface[]
      */
     public function getRules(): array;
+
+    public function mapQueryVariable(string $queryVariable): ?string;
 }

--- a/src/RewriteInterface.php
+++ b/src/RewriteInterface.php
@@ -26,5 +26,9 @@ interface RewriteInterface
      */
     public function getRules(): array;
 
+    public function handle(array $queryVariables = []);
+
+    public function isActive(): bool;
+
     public function mapQueryVariable(string $queryVariable): ?string;
 }

--- a/src/RewriteRule.php
+++ b/src/RewriteRule.php
@@ -8,17 +8,7 @@ class RewriteRule implements RewriteRuleInterface
 {
     protected string $prefix = '';
 
-    /**
-     * @var array<string, string>
-     */
-    protected array $prefixedQueryArray;
-
     protected string $query;
-
-    /**
-     * @var array<string, string>
-     */
-    protected array $queryArray;
 
     /**
      * @var array<string, string>
@@ -43,27 +33,9 @@ class RewriteRule implements RewriteRuleInterface
         return md5($this->regex);
     }
 
-    /**
-     *
-     * @return array<string, string>
-     */
-    public function getPrefixedQueryArray(): array
-    {
-        return $this->prefixedQueryArray;
-    }
-
     public function getQuery(): string
     {
         return $this->query;
-    }
-
-    /**
-     *
-     * @return array<string, string>
-     */
-    public function getQueryArray(): array
-    {
-        return $this->queryArray;
     }
 
     public function getQueryVariables(): array
@@ -86,9 +58,7 @@ class RewriteRule implements RewriteRuleInterface
 
         $query = Support::buildQuery($prefixedQueryArray);
 
-        $this->prefixedQueryArray = $prefixedQueryArray;
         $this->query = $query;
-        $this->queryArray = $queryArray;
         $this->queryVariables = array_combine(
             array_keys($prefixedQueryArray),
             array_keys($queryArray)

--- a/src/RewriteRule.php
+++ b/src/RewriteRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ToyWpRouting;
 
-// @todo More getters? prefixedToUnprefixedVariableMap, queryVariables, prefix, queryArray, prefixedQueryArray, individual values from query array?
 class RewriteRule implements RewriteRuleInterface
 {
     protected string $prefix = '';
@@ -21,6 +20,11 @@ class RewriteRule implements RewriteRuleInterface
      */
     protected array $queryArray;
 
+    /**
+     * @var array<string, string>
+     */
+    protected array $queryVariables;
+
     protected string $rawQuery;
 
     protected string $regex;
@@ -31,7 +35,6 @@ class RewriteRule implements RewriteRuleInterface
         $this->rawQuery = $query;
         $this->prefix = $prefix;
 
-        // @todo Lazily parse query for cached rewrite collection sake?
         $this->parseQuery();
     }
 
@@ -63,6 +66,11 @@ class RewriteRule implements RewriteRuleInterface
         return $this->queryArray;
     }
 
+    public function getQueryVariables(): array
+    {
+        return $this->queryVariables;
+    }
+
     public function getRegex(): string
     {
         return $this->regex;
@@ -81,5 +89,9 @@ class RewriteRule implements RewriteRuleInterface
         $this->prefixedQueryArray = $prefixedQueryArray;
         $this->query = $query;
         $this->queryArray = $queryArray;
+        $this->queryVariables = array_combine(
+            array_keys($prefixedQueryArray),
+            array_keys($queryArray)
+        );
     }
 }

--- a/src/RewriteRuleInterface.php
+++ b/src/RewriteRuleInterface.php
@@ -4,22 +4,11 @@ declare(strict_types=1);
 
 namespace ToyWpRouting;
 
-// @todo toArray(), fromArray() methods?
 interface RewriteRuleInterface
 {
     public function getHash(): string;
 
-    /**
-     * @return array<string, string>
-     */
-    public function getPrefixedQueryArray(): array;
-
     public function getQuery(): string;
-
-    /**
-     * @return array<string, string>
-     */
-    public function getQueryArray(): array;
 
     /**
      * @return array<string, string>

--- a/src/RewriteRuleInterface.php
+++ b/src/RewriteRuleInterface.php
@@ -21,5 +21,10 @@ interface RewriteRuleInterface
      */
     public function getQueryArray(): array;
 
+    /**
+     * @return array<string, string>
+     */
+    public function getQueryVariables(): array;
+
     public function getRegex(): string;
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -14,6 +14,11 @@ class Route
     protected $handler;
 
     /**
+     * @var ?InvocationStrategyInterface
+     */
+    protected $invocationStrategy;
+
+    /**
      * @var mixed
      */
     protected $isActiveCallback;
@@ -50,6 +55,11 @@ class Route
         return $this->handler;
     }
 
+    public function getInvocationStrategy(): ?InvocationStrategyInterface
+    {
+        return $this->invocationStrategy;
+    }
+
     /**
      * @return mixed
      */
@@ -74,6 +84,13 @@ class Route
     public function getRoute(): string
     {
         return $this->route;
+    }
+
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): self
+    {
+        $this->invocationStrategy = $invocationStrategy;
+
+        return $this;
     }
 
     public function setPrefix(string $prefix): self

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -27,20 +27,10 @@ class RouteCollection
         $this->invocationStrategy = $invocationStrategy ?: new DefaultInvocationStrategy();
     }
 
-    /**
-     * @param array<int, "GET"|"HEAD"|"POST"|"PUT"|"PATCH"|"DELETE"|"OPTIONS"> $methods
-     * @param mixed $handler
-     */
-    public function add(array $methods, string $route, $handler): Route
+    public function add(Route $route): Route
     {
         if ($this->locked) {
             throw new RuntimeException('Cannot add routes when route collection is locked');
-        }
-
-        $route = new Route($methods, $route, $handler);
-
-        if ('' !== $this->prefix) {
-            $route->setPrefix($this->prefix);
         }
 
         $this->routes[] = $route;
@@ -54,9 +44,11 @@ class RouteCollection
     public function any(string $route, $handler): Route
     {
         return $this->add(
-            ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-            $route,
-            $handler
+            $this->create(
+                ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+                $route,
+                $handler
+            )
         );
     }
 
@@ -65,7 +57,9 @@ class RouteCollection
      */
     public function delete(string $route, $handler): Route
     {
-        return $this->add(['DELETE'], $route, $handler);
+        return $this->add(
+            $this->create(['DELETE'], $route, $handler)
+        );
     }
 
     /**
@@ -73,7 +67,9 @@ class RouteCollection
      */
     public function get(string $route, $handler): Route
     {
-        return $this->add(['GET', 'HEAD'], $route, $handler);
+        return $this->add(
+            $this->create(['GET', 'HEAD'], $route, $handler)
+        );
     }
 
     public function getInvocationStrategy(): InvocationStrategyInterface
@@ -111,7 +107,9 @@ class RouteCollection
      */
     public function options(string $route, $handler): Route
     {
-        return $this->add(['OPTIONS'], $route, $handler);
+        return $this->add(
+            $this->create(['OPTIONS'], $route, $handler)
+        );
     }
 
     /**
@@ -119,7 +117,9 @@ class RouteCollection
      */
     public function patch(string $route, $handler): Route
     {
-        return $this->add(['PATCH'], $route, $handler);
+        return $this->add(
+            $this->create(['PATCH'], $route, $handler)
+        );
     }
 
     /**
@@ -127,7 +127,9 @@ class RouteCollection
      */
     public function post(string $route, $handler): Route
     {
-        return $this->add(['POST'], $route, $handler);
+        return $this->add(
+            $this->create(['POST'], $route, $handler)
+        );
     }
 
     /**
@@ -135,6 +137,25 @@ class RouteCollection
      */
     public function put(string $route, $handler): Route
     {
-        return $this->add(['PUT'], $route, $handler);
+        return $this->add(
+            $this->create(['PUT'], $route, $handler)
+        );
+    }
+
+    /**
+     * @param array<int, "GET"|"HEAD"|"POST"|"PUT"|"PATCH"|"DELETE"|"OPTIONS"> $methods
+     * @param mixed $handler
+     */
+    protected function create(array $methods, string $route, $handler): Route
+    {
+        $route = new Route($methods, $route, $handler);
+
+        if ('' !== $this->prefix) {
+            $route->setPrefix($this->prefix);
+        }
+
+        $route->setInvocationStrategy($this->invocationStrategy);
+
+        return $route;
     }
 }

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -8,6 +8,8 @@ use RuntimeException;
 
 class RouteCollection
 {
+    protected InvocationStrategyInterface $invocationStrategy;
+
     protected bool $locked = false;
 
     protected string $prefix;
@@ -17,9 +19,12 @@ class RouteCollection
      */
     protected array $routes = [];
 
-    public function __construct(string $prefix = '')
-    {
+    public function __construct(
+        string $prefix = '',
+        ?InvocationStrategyInterface $invocationStrategy = null
+    ) {
         $this->prefix = $prefix;
+        $this->invocationStrategy = $invocationStrategy ?: new DefaultInvocationStrategy();
     }
 
     /**
@@ -69,6 +74,11 @@ class RouteCollection
     public function get(string $route, $handler): Route
     {
         return $this->add(['GET', 'HEAD'], $route, $handler);
+    }
+
+    public function getInvocationStrategy(): InvocationStrategyInterface
+    {
+        return $this->invocationStrategy;
     }
 
     public function getPrefix(): string

--- a/src/RouteConverter.php
+++ b/src/RouteConverter.php
@@ -31,6 +31,12 @@ class RouteConverter
             $route->getHandler()
         );
 
+        $invocationStrategy = $route->getInvocationStrategy();
+
+        if ($invocationStrategy instanceof InvocationStrategyInterface) {
+            $rewrite->setInvocationStrategy($invocationStrategy);
+        }
+
         if (null !== $isActiveCallback = $route->getIsActiveCallback()) {
             $rewrite->setIsActiveCallback($isActiveCallback);
         }
@@ -49,7 +55,10 @@ class RouteConverter
 
         foreach ($routeCollection->getRoutes() as $route) {
             $rewrite = $this->convert($route);
-            $rewrite->setInvocationStrategy($invocationStrategy);
+
+            if (! $route->getInvocationStrategy() instanceof InvocationStrategyInterface) {
+                $rewrite->setInvocationStrategy($invocationStrategy);
+            }
 
             $rewriteCollection->add($rewrite);
         }

--- a/src/RouteConverter.php
+++ b/src/RouteConverter.php
@@ -40,10 +40,18 @@ class RouteConverter
 
     public function convertCollection(RouteCollection $routeCollection): RewriteCollection
     {
-        $rewriteCollection = new RewriteCollection($routeCollection->getPrefix());
+        $invocationStrategy = $routeCollection->getInvocationStrategy();
+
+        $rewriteCollection = new RewriteCollection(
+            $routeCollection->getPrefix(),
+            $invocationStrategy
+        );
 
         foreach ($routeCollection->getRoutes() as $route) {
-            $rewriteCollection->add($this->convert($route));
+            $rewrite = $this->convert($route);
+            $rewrite->setInvocationStrategy($invocationStrategy);
+
+            $rewriteCollection->add($rewrite);
         }
 
         return $rewriteCollection;

--- a/src/Support.php
+++ b/src/Support.php
@@ -44,6 +44,10 @@ class Support
 
     public static function isValidMethodsList(array $methods): bool
     {
+        if ([] === $methods) {
+            return false;
+        }
+
         return empty(array_diff(
             $methods,
             ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']

--- a/src/Support.php
+++ b/src/Support.php
@@ -11,6 +11,10 @@ class Support
 {
     public static function applyPrefix(string $value, string $prefix): string
     {
+        if ('' === $prefix) {
+            return $value;
+        }
+
         if ($prefix === substr($value, 0, strlen($prefix))) {
             return $value;
         }
@@ -20,6 +24,10 @@ class Support
 
     public static function applyPrefixToKeys(array $array, string $prefix): array
     {
+        if ('' === $prefix) {
+            return $array;
+        }
+
         $newArray = [];
 
         foreach ($array as $key => $value) {

--- a/src/Support.php
+++ b/src/Support.php
@@ -65,7 +65,7 @@ class Support
     public static function parseQuery(string $query): array
     {
         if ('index.php?' === substr($query, 0, 10)) {
-            $query = substr_replace($query, '', 0, 10);
+            $query = substr($query, 10);
         }
 
         parse_str($query, $result);

--- a/tests/AbstractInvocationStrategyTest.php
+++ b/tests/AbstractInvocationStrategyTest.php
@@ -38,8 +38,9 @@ class AbstractInvocationStrategyTest extends TestCase
             ]]);
 
         $rewrite = $this->createStub(RewriteInterface::class);
-        $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
-            ->willReturn(['someqv' => 'someqv']);
+        $rewrite->method('mapQueryVariable')
+            ->withConsecutive(['someqv'], ['unusedqv'])
+            ->willReturnOnConsecutiveCalls('someqv', null);
 
         $this->assertSame(
             ['someqv' => 'someval'],
@@ -53,7 +54,7 @@ class AbstractInvocationStrategyTest extends TestCase
 
         $rewrite = $this->createMock(RewriteInterface::class);
         $rewrite->expects($this->never())
-            ->method('getPrefixedToUnprefixedQueryVariablesMap');
+            ->method('mapQueryVariable');
 
         $this->assertSame([], $strategy->relevantQueryVariablesProxy($rewrite));
     }
@@ -67,8 +68,9 @@ class AbstractInvocationStrategyTest extends TestCase
             ]]);
 
         $rewrite = $this->createStub(RewriteInterface::class);
-        $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
-            ->willReturn(['pfx_someqv' => 'someqv']);
+        $rewrite->method('mapQueryVariable')
+            ->withConsecutive(['pfx_someqv'], ['pfx_unusedqv'])
+            ->willReturnOnConsecutiveCalls('someqv', null);
 
         $this->assertSame(
             ['someqv' => 'someval'],

--- a/tests/AbstractInvocationStrategyTest.php
+++ b/tests/AbstractInvocationStrategyTest.php
@@ -6,9 +6,7 @@ namespace ToyWpRouting\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ToyWpRouting\AbstractInvocationStrategy;
-use ToyWpRouting\Rewrite;
 use ToyWpRouting\RewriteInterface;
-use ToyWpRouting\RewriteRule;
 
 class AbstractInvocationStrategyTest extends TestCase
 {
@@ -39,16 +37,13 @@ class AbstractInvocationStrategyTest extends TestCase
                 'unusedqv' => 'unusedval',
             ]]);
 
+        $rewrite = $this->createStub(RewriteInterface::class);
+        $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
+            ->willReturn(['someqv' => 'someqv']);
+
         $this->assertSame(
             ['someqv' => 'someval'],
-            $strategy->relevantQueryVariablesProxy(
-                new Rewrite(
-                    [],
-                    [new RewriteRule('^one$', 'index.php?someqv=someval')],
-                    function () {
-                    }
-                )
-            )
+            $strategy->relevantQueryVariablesProxy($rewrite)
         );
     }
 
@@ -56,11 +51,11 @@ class AbstractInvocationStrategyTest extends TestCase
     {
         $strategy = $this->createInvocationStrategy();
 
-        $this->assertSame(
-            [],
-            $strategy->relevantQueryVariablesProxy(new Rewrite([], [], function () {
-            }))
-        );
+        $rewrite = $this->createMock(RewriteInterface::class);
+        $rewrite->expects($this->never())
+            ->method('getPrefixedToUnprefixedQueryVariablesMap');
+
+        $this->assertSame([], $strategy->relevantQueryVariablesProxy($rewrite));
     }
 
     public function testResolveRelevantQueryVariablesFromAdditionalContextWithPrefix()
@@ -71,16 +66,13 @@ class AbstractInvocationStrategyTest extends TestCase
                 'pfx_unusedqv' => 'unusedval',
             ]]);
 
+        $rewrite = $this->createStub(RewriteInterface::class);
+        $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
+            ->willReturn(['pfx_someqv' => 'someqv']);
+
         $this->assertSame(
             ['someqv' => 'someval'],
-            $strategy->relevantQueryVariablesProxy(
-                new Rewrite(
-                    [],
-                    [new RewriteRule('^one$', 'index.php?someqv=someval', 'pfx_')],
-                    function () {
-                    }
-                )
-            )
+            $strategy->relevantQueryVariablesProxy($rewrite)
         );
     }
 

--- a/tests/Compiler/OptimizedRewriteTest.php
+++ b/tests/Compiler/OptimizedRewriteTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Tests;
+namespace ToyWpRouting\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use ToyWpRouting\Compiler\OptimizedRewrite;
 use ToyWpRouting\InvocationStrategyInterface;
-use ToyWpRouting\OptimizedRewrite;
 use ToyWpRouting\RewriteRule;
 
 class OptimizedRewriteTest extends TestCase

--- a/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
@@ -11,8 +11,6 @@ return new class extends \ToyWpRouting\RewriteCollection
         $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  '^regex$' => 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'some' => 'var',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -23,14 +21,11 @@ return new class extends \ToyWpRouting\RewriteCollection
   'some' => 'some',
   'matchedRule' => 'matchedRule',
 ), '^regex$'),
-), static function () {
-        }, array (
+), array (
   'some' => 'some',
   'matchedRule' => 'matchedRule',
-), array (
-  0 => 'some',
-  1 => 'matchedRule',
-), NULL);
+), static function () {
+        }, NULL);
 $this->rewrites->attach($rewrite0);
 
         $this->rewriteRules = array (

--- a/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
@@ -11,10 +11,10 @@ return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy 
         {
             parent::__construct('', $invocationStrategy);
 
-            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+            $this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'some' => 'some',
   'matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
@@ -19,6 +19,9 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'some' => 'var',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'some' => 'some',
+  'matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), static function () {
         }, array (

--- a/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
@@ -11,13 +11,7 @@ return new class extends \ToyWpRouting\RewriteCollection
         $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'some' => 'var',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'some' => 'var',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'some' => 'some',
   'matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCollectionCompilerTest__testCompile__1.txt
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
-return new class extends \ToyWpRouting\RewriteCollection
-{
-    public function __construct()
+return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null) {
+    return new class($invocationStrategy) extends \ToyWpRouting\RewriteCollection
     {
-        parent::__construct('');
+        protected bool $locked = true;
 
-        $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
+        public function __construct(?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null)
+        {
+            parent::__construct('', $invocationStrategy);
+
+            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
@@ -18,25 +21,8 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), array (
   'some' => 'some',
   'matchedRule' => 'matchedRule',
-), static function () {
-        }, NULL);
-$this->rewrites->attach($rewrite0);
-
-        $this->rewriteRules = array (
-  '^regex$' => 'index.php?some=var&matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-);
-        $this->queryVariables = array (
-  'some' => 'some',
-  'matchedRule' => 'matchedRule',
-);
-
-        $this->rewritesByRegexHashAndMethod = array (
-  'e8362b7488c4e1a7eee5ff88b032f6eb' => 
-  array (
-    'POST' => $rewrite0,
-  ),
-);
-
-        $this->locked = true;
-    }
+), $this->invocationStrategy, static function () {
+        }, NULL));
+        }
+    };
 };

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
@@ -2,13 +2,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'value',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'value',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
@@ -1,8 +1,8 @@
-new \ToyWpRouting\OptimizedRewrite(array (
+new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
@@ -10,6 +10,9 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'value',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), array (
   0 => 'handlerclass',

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
@@ -2,8 +2,6 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  '^regex$' => 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'value',
   'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -15,14 +13,11 @@ new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), array (
-  0 => 'handlerclass',
-  1 => 'handlermethod',
-), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
+  0 => 'handlerclass',
+  1 => 'handlermethod',
 ), array (
   0 => 'isactiveclass',
   1 => 'isactivemethod',

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithArrayCallbacks__1.txt
@@ -9,7 +9,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
+), $this->invocationStrategy, array (
   0 => 'handlerclass',
   1 => 'handlermethod',
 ), array (

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
@@ -2,13 +2,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'value',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'value',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
@@ -2,8 +2,6 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  '^regex$' => 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'value',
   'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -14,12 +12,9 @@ new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
-), static function () {
-            }, array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
 ), static function () {
+            }, static function () {
         })

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
@@ -1,8 +1,8 @@
-new \ToyWpRouting\OptimizedRewrite(array (
+new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
@@ -10,6 +10,9 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'value',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), static function () {
             }, array (

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithClosureCallbacks__1.txt
@@ -9,6 +9,6 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), static function () {
+), $this->invocationStrategy, static function () {
             }, static function () {
         })

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
@@ -9,5 +9,5 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), static function () {
+), $this->invocationStrategy, static function () {
             }, NULL)

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
@@ -2,13 +2,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'value',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'value',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
@@ -1,8 +1,8 @@
-new \ToyWpRouting\OptimizedRewrite(array (
+new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
@@ -10,6 +10,9 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'value',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), static function () {
             }, array (

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithNoIsActiveCallback__1.txt
@@ -2,8 +2,6 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  '^regex$' => 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'value',
   'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -14,11 +12,8 @@ new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
-), static function () {
-            }, array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
-), NULL)
+), static function () {
+            }, NULL)

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
@@ -2,13 +2,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'value',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'value',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
@@ -2,8 +2,6 @@ new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  '^regex$' => 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'value',
   'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -14,10 +12,7 @@ new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
-), 'handler', array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
-), 'isactivecallback')
+), 'handler', 'isactivecallback')

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
@@ -1,8 +1,8 @@
-new \ToyWpRouting\OptimizedRewrite(array (
+new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
@@ -9,4 +9,4 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), 'handler', 'isactivecallback')
+), $this->invocationStrategy, 'handler', 'isactivecallback')

--- a/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteCompilerTest__testCompileWithStringCallbacks__1.txt
@@ -10,6 +10,9 @@ new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'value',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), 'handler', array (
   'pfx_var' => 'var',

--- a/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
@@ -2,13 +2,7 @@ $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('2c74a3787bae884d9648eb0bc7e3c8a0', array (
-  'pfx_var' => 'get',
-  'pfx_matchedRule' => '2c74a3787bae884d9648eb0bc7e3c8a0',
-), 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0', array (
-  'var' => 'get',
-  'matchedRule' => '2c74a3787bae884d9648eb0bc7e3c8a0',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('2c74a3787bae884d9648eb0bc7e3c8a0', 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^getregex$'),
@@ -22,13 +16,7 @@ $this->rewrites->attach($rewrite0);
 $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', array (
-  'pfx_var' => 'post',
-  'pfx_matchedRule' => '9a3f43b00ec8400aee6a7ef0191ede24',
-), 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
-  'var' => 'post',
-  'matchedRule' => '9a3f43b00ec8400aee6a7ef0191ede24',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^postregex$'),

--- a/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
@@ -10,6 +10,9 @@ $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0', array (
   'var' => 'get',
   'matchedRule' => '2c74a3787bae884d9648eb0bc7e3c8a0',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^getregex$'),
 ), static function () {
             }, array (
@@ -32,6 +35,9 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
   'var' => 'post',
   'matchedRule' => '9a3f43b00ec8400aee6a7ef0191ede24',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^postregex$'),
 ), static function () {
             }, array (

--- a/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
@@ -1,4 +1,4 @@
-$rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
+$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
@@ -9,11 +9,10 @@ $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), static function () {
+), $this->invocationStrategy, static function () {
             }, static function () {
-        });
-$this->rewrites->attach($rewrite0);
-$rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
+        }));
+$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
@@ -23,6 +22,5 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), static function () {
-            }, NULL);
-$this->rewrites->attach($rewrite1);
+), $this->invocationStrategy, static function () {
+            }, NULL));

--- a/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
@@ -2,8 +2,6 @@ $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  '^getregex$' => 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('2c74a3787bae884d9648eb0bc7e3c8a0', array (
   'pfx_var' => 'get',
   'pfx_matchedRule' => '2c74a3787bae884d9648eb0bc7e3c8a0',
@@ -14,20 +12,15 @@ $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^getregex$'),
-), static function () {
-            }, array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
 ), static function () {
+            }, static function () {
         });
 $this->rewrites->attach($rewrite0);
 $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
-), array (
-  '^postregex$' => 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24',
 ), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', array (
   'pfx_var' => 'post',
@@ -39,12 +32,9 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^postregex$'),
-), static function () {
-            }, array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
-), NULL);
+), static function () {
+            }, NULL);
 $this->rewrites->attach($rewrite1);

--- a/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteListDefinitionsCompilerTest__testCompile__1.txt
@@ -1,8 +1,8 @@
-$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+$this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('2c74a3787bae884d9648eb0bc7e3c8a0', 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('2c74a3787bae884d9648eb0bc7e3c8a0', 'index.php?pfx_var=get&pfx_matchedRule=2c74a3787bae884d9648eb0bc7e3c8a0', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^getregex$'),
@@ -12,10 +12,10 @@ $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
 ), $this->invocationStrategy, static function () {
             }, static function () {
         }));
-$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+$this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('9a3f43b00ec8400aee6a7ef0191ede24', 'index.php?pfx_var=post&pfx_matchedRule=9a3f43b00ec8400aee6a7ef0191ede24', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^postregex$'),

--- a/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
@@ -4,4 +4,7 @@ new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array
 ), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'value',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$')

--- a/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
@@ -1,10 +1,4 @@
-new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'value',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'value',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$')

--- a/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleCompilerTest__testCompile__1.txt
@@ -1,4 +1,4 @@
-new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=value&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$')

--- a/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
@@ -1,9 +1,9 @@
 array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('c43997731c5fc6fbc8b82cacbcb57daf', 'index.php?pfx_var=one&pfx_matchedRule=c43997731c5fc6fbc8b82cacbcb57daf', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('c43997731c5fc6fbc8b82cacbcb57daf', 'index.php?pfx_var=one&pfx_matchedRule=c43997731c5fc6fbc8b82cacbcb57daf', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^oneregex$'),
-  1 => new \ToyWpRouting\OptimizedRewriteRule('c5090b1b8a5d15fa926bd867aaeeee18', 'index.php?pfx_var=two&pfx_matchedRule=c5090b1b8a5d15fa926bd867aaeeee18', array (
+  1 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('c5090b1b8a5d15fa926bd867aaeeee18', 'index.php?pfx_var=two&pfx_matchedRule=c5090b1b8a5d15fa926bd867aaeeee18', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^tworegex$'),

--- a/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
@@ -1,21 +1,9 @@
 array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('c43997731c5fc6fbc8b82cacbcb57daf', array (
-  'pfx_var' => 'one',
-  'pfx_matchedRule' => 'c43997731c5fc6fbc8b82cacbcb57daf',
-), 'index.php?pfx_var=one&pfx_matchedRule=c43997731c5fc6fbc8b82cacbcb57daf', array (
-  'var' => 'one',
-  'matchedRule' => 'c43997731c5fc6fbc8b82cacbcb57daf',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('c43997731c5fc6fbc8b82cacbcb57daf', 'index.php?pfx_var=one&pfx_matchedRule=c43997731c5fc6fbc8b82cacbcb57daf', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^oneregex$'),
-  1 => new \ToyWpRouting\OptimizedRewriteRule('c5090b1b8a5d15fa926bd867aaeeee18', array (
-  'pfx_var' => 'two',
-  'pfx_matchedRule' => 'c5090b1b8a5d15fa926bd867aaeeee18',
-), 'index.php?pfx_var=two&pfx_matchedRule=c5090b1b8a5d15fa926bd867aaeeee18', array (
-  'var' => 'two',
-  'matchedRule' => 'c5090b1b8a5d15fa926bd867aaeeee18',
-), array (
+  1 => new \ToyWpRouting\OptimizedRewriteRule('c5090b1b8a5d15fa926bd867aaeeee18', 'index.php?pfx_var=two&pfx_matchedRule=c5090b1b8a5d15fa926bd867aaeeee18', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^tworegex$'),

--- a/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
+++ b/tests/Compiler/__snapshots__/RewriteRuleListCompilerTest__testCompile__1.txt
@@ -5,6 +5,9 @@ array (
 ), 'index.php?pfx_var=one&pfx_matchedRule=c43997731c5fc6fbc8b82cacbcb57daf', array (
   'var' => 'one',
   'matchedRule' => 'c43997731c5fc6fbc8b82cacbcb57daf',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^oneregex$'),
   1 => new \ToyWpRouting\OptimizedRewriteRule('c5090b1b8a5d15fa926bd867aaeeee18', array (
   'pfx_var' => 'two',
@@ -12,5 +15,8 @@ array (
 ), 'index.php?pfx_var=two&pfx_matchedRule=c5090b1b8a5d15fa926bd867aaeeee18', array (
   'var' => 'two',
   'matchedRule' => 'c5090b1b8a5d15fa926bd867aaeeee18',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^tworegex$'),
 )

--- a/tests/CreatesRewriteStubs.php
+++ b/tests/CreatesRewriteStubs.php
@@ -24,8 +24,8 @@ trait CreatesRewriteStubs
         }
 
         if (array_key_exists('qvMap', $args)) {
-            $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
-                ->willReturn($args['qvMap']);
+            $rewrite->method('mapQueryVariable')
+                ->willReturnCallback(fn ($queryVariable) => $args['qvMap'][$queryVariable] ?? null);
         }
 
         return $rewrite;

--- a/tests/CreatesRewriteStubs.php
+++ b/tests/CreatesRewriteStubs.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ToyWpRouting\Tests;
+
+use ToyWpRouting\RewriteInterface;
+
+trait CreatesRewriteStubs
+{
+    /**
+     * @param array{handler?: mixed, isActive?: mixed, qvMap?: array} $args
+     */
+    private function createRewriteStub(array $args = [])
+    {
+        $rewrite = $this->createStub(RewriteInterface::class);
+
+        if (array_key_exists('handler', $args)) {
+            $rewrite->method('getHandler')->willReturn($args['handler']);
+        }
+
+        if (array_key_exists('isActive', $args)) {
+            $rewrite->method('getIsActiveCallback')->willReturn($args['isActive']);
+        }
+
+        if (array_key_exists('qvMap', $args)) {
+            $rewrite->method('getPrefixedToUnprefixedQueryVariablesMap')
+                ->willReturn($args['qvMap']);
+        }
+
+        return $rewrite;
+    }
+}

--- a/tests/CreatesRewriteStubs.php
+++ b/tests/CreatesRewriteStubs.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ToyWpRouting\Tests;
 
 use ToyWpRouting\RewriteInterface;

--- a/tests/InvokerBackedInvocationStrategyTest.php
+++ b/tests/InvokerBackedInvocationStrategyTest.php
@@ -7,7 +7,6 @@ namespace ToyWpRouting\Tests;
 use Invoker\InvokerInterface;
 use PHPUnit\Framework\TestCase;
 use ToyWpRouting\InvokerBackedInvocationStrategy;
-use ToyWpRouting\RewriteInterface;
 
 // @todo Test with custom resolver set on Invoker instance?
 // @todo Move additional parameter tests to dedicated abstract invocation strategy test.

--- a/tests/OptimizedRewriteTest.php
+++ b/tests/OptimizedRewriteTest.php
@@ -6,6 +6,7 @@ namespace ToyWpRouting\Tests;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use ToyWpRouting\InvocationStrategyInterface;
 use ToyWpRouting\OptimizedRewrite;
 use ToyWpRouting\RewriteRule;
 
@@ -17,6 +18,7 @@ class OptimizedRewriteTest extends TestCase
             ['GET'],
             $rules = [new RewriteRule('someregex', 'index.php?var=value', 'pfx_')],
             ['pfx_var' => 'var'],
+            $this->createStub(InvocationStrategyInterface::class),
             'somehandler',
             'isActiveCallback'
         );
@@ -39,6 +41,7 @@ class OptimizedRewriteTest extends TestCase
                 'some' => 'some',
                 'pfx_another' => 'another',
             ],
+            $this->createStub(InvocationStrategyInterface::class),
             'somehandler',
             'isActiveCallback'
         );
@@ -47,6 +50,21 @@ class OptimizedRewriteTest extends TestCase
         $this->assertSame('another', $rewrite->mapQueryVariable('pfx_another'));
         $this->assertNull($rewrite->mapQueryVariable('another'));
         $this->assertNull($rewrite->mapQueryVariable('andanother'));
+    }
+
+    public function testSetInvocationStrategy()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot override invocationStrategy');
+
+        $rewrite = new OptimizedRewrite(
+            ['GET'],
+            [new RewriteRule('someregex', 'some=query')],
+            ['some' => 'some'],
+            $this->createStub(InvocationStrategyInterface::class),
+            'somehandler'
+        );
+        $rewrite->setInvocationStrategy($this->createStub(InvocationStrategyInterface::class));
     }
 
     public function testSetIsActiveCallback()
@@ -58,6 +76,7 @@ class OptimizedRewriteTest extends TestCase
             ['GET'],
             [new RewriteRule('someregex', 'some=query')],
             ['some' => 'some'],
+            $this->createStub(InvocationStrategyInterface::class),
             'somehandler'
         );
         $rewrite->setIsActiveCallback('someisactivecallback');

--- a/tests/OrchestratorTest.php
+++ b/tests/OrchestratorTest.php
@@ -65,13 +65,12 @@ class OrchestratorTest extends TestCase
         $orchestrator = new Orchestrator($rewrites);
 
         $active = $orchestrator->getActiveRewriteCollection();
-        $activeHash = md5('someregex');
 
         $this->assertInstanceOf(RewriteCollection::class, $active);
         $this->assertCount(1, $active->getRewrites());
         $this->assertSame(
-            ['someregex' => "index.php?var=value&matchedRule={$activeHash}"],
-            $active->getRewrites()->current()->getRewriteRules()
+            'somehandler',
+            $active->getRewrites()->current()->getHandler()
         );
 
         // Result is cached.

--- a/tests/OrchestratorTest.php
+++ b/tests/OrchestratorTest.php
@@ -6,7 +6,6 @@ namespace ToyWpRouting\Tests;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use ToyWpRouting\DefaultInvocationStrategy;
 use ToyWpRouting\MethodNotAllowedResponder;
 use ToyWpRouting\Orchestrator;
 use ToyWpRouting\RequestContext;
@@ -38,43 +37,6 @@ class OrchestratorTest extends TestCase
 
         $this->regex = null;
         $this->hash = null;
-    }
-
-    public function testDefaults()
-    {
-        $orchestrator = new Orchestrator(new RewriteCollection());
-
-        $this->assertInstanceOf(
-            DefaultInvocationStrategy::class,
-            $orchestrator->getInvocationStrategy()
-        );
-    }
-
-    public function testGetActiveRewriteCollection()
-    {
-        $rewrites = new RewriteCollection();
-        $rewrites->get('someregex', 'index.php?var=value', 'somehandler');
-        $rewrites->get(
-            'anotherregex',
-            'index.php?anothervar=anothervalue',
-            'anotherhandler'
-        )->setIsActiveCallback(function () {
-            return false;
-        });
-
-        $orchestrator = new Orchestrator($rewrites);
-
-        $active = $orchestrator->getActiveRewriteCollection();
-
-        $this->assertInstanceOf(RewriteCollection::class, $active);
-        $this->assertCount(1, $active->getRewrites());
-        $this->assertSame(
-            'somehandler',
-            $active->getRewrites()->current()->getHandler()
-        );
-
-        // Result is cached.
-        $this->assertSame($active, $orchestrator->getActiveRewriteCollection());
     }
 
     public function testOnOptionRewriteRulesAndOnRewriteRulesArray()
@@ -236,7 +198,7 @@ class OrchestratorTest extends TestCase
             $count++;
         });
 
-        $orchestrator = new Orchestrator($rewrites, null, new RequestContext('GET', []));
+        $orchestrator = new Orchestrator($rewrites, new RequestContext('GET', []));
 
         $orchestrator->onRequest(['matchedRule' => $this->hash]);
 
@@ -250,7 +212,7 @@ class OrchestratorTest extends TestCase
             throw new RuntimeException('This should not happen');
         });
 
-        $orchestrator = new Orchestrator($rewrites, null, new RequestContext('POST', []));
+        $orchestrator = new Orchestrator($rewrites, new RequestContext('POST', []));
 
         $orchestrator->onRequest(['matchedRule' => $this->hash]);
 
@@ -304,7 +266,7 @@ class OrchestratorTest extends TestCase
             return $responder;
         });
 
-        $orchestrator = new Orchestrator($rewrites, null, new RequestContext('GET', []));
+        $orchestrator = new Orchestrator($rewrites, new RequestContext('GET', []));
 
         $orchestrator->onRequest(['matchedRule' => $this->hash]);
 
@@ -313,7 +275,6 @@ class OrchestratorTest extends TestCase
 
     public function testOnRequestMatchedRewriteWithVariables()
     {
-        // @todo Test with invoker backed strategy?
         $foundId = $foundFormat = null;
 
         $rewrites = new RewriteCollection();
@@ -327,7 +288,7 @@ class OrchestratorTest extends TestCase
             }
         );
 
-        $orchestrator = new Orchestrator($rewrites, null, new RequestContext('GET', []));
+        $orchestrator = new Orchestrator($rewrites, new RequestContext('GET', []));
 
         $orchestrator->onRequest([
             'matchedRule' => $this->hash,

--- a/tests/RewriteCollectionCacheTest.php
+++ b/tests/RewriteCollectionCacheTest.php
@@ -117,7 +117,7 @@ class RewriteCollectionCacheTest extends TestCase
         $this->assertTrue($root->hasChild('cache.php'));
         $this->assertInstanceOf(
             RewriteCollection::class,
-            include $root->getChild('cache.php')->url()
+            (include $root->getChild('cache.php')->url())()
         );
     }
 
@@ -147,7 +147,7 @@ class RewriteCollectionCacheTest extends TestCase
 
         $this->assertInstanceOf(
             RewriteCollection::class,
-            include $root->getChild('cache.php')->url()
+            (include $root->getChild('cache.php')->url())()
         );
 
         $rewriteCollection->add(
@@ -185,7 +185,7 @@ class RewriteCollectionCacheTest extends TestCase
 
         $cache->put($rewriteCollection);
 
-        $dumped = include $root->getChild('cache.php')->url();
+        $dumped = (include $root->getChild('cache.php')->url())();
         $dumpedRewrites = iterator_to_array($dumped->getRewrites());
 
         $this->assertInstanceOf(Closure::class, $dumpedRewrites[0]->getHandler());

--- a/tests/RewriteCollectionCacheTest.php
+++ b/tests/RewriteCollectionCacheTest.php
@@ -58,7 +58,7 @@ class RewriteCollectionCacheTest extends TestCase
         $this->assertInstanceOf(OptimizedRewrite::class, $rewrites[0]);
         $this->assertSame('firsthandler', $rewrites[0]->getHandler());
         $this->assertNull($rewrites[0]->getIsActiveCallback());
-        $this->assertSame(['GET'], $rewrites[0]->getMethods());
+        $this->assertSame(['GET', 'HEAD'], $rewrites[0]->getMethods());
         $this->assertSame(['var' => 'var', 'matchedRule' => 'matchedRule'], $rewrites[0]->getPrefixedToUnprefixedQueryVariablesMap());
         $this->assertSame(['var', 'matchedRule'], $rewrites[0]->getQueryVariables());
         $this->assertSame(

--- a/tests/RewriteCollectionCacheTest.php
+++ b/tests/RewriteCollectionCacheTest.php
@@ -7,7 +7,7 @@ namespace ToyWpRouting\Tests;
 use Closure;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
-use ToyWpRouting\OptimizedRewrite;
+use ToyWpRouting\Compiler\OptimizedRewrite;
 use ToyWpRouting\Rewrite;
 use ToyWpRouting\RewriteCollection;
 use ToyWpRouting\RewriteCollectionCache;

--- a/tests/RewriteCollectionCacheTest.php
+++ b/tests/RewriteCollectionCacheTest.php
@@ -59,12 +59,6 @@ class RewriteCollectionCacheTest extends TestCase
         $this->assertSame('firsthandler', $rewrites[0]->getHandler());
         $this->assertNull($rewrites[0]->getIsActiveCallback());
         $this->assertSame(['GET', 'HEAD'], $rewrites[0]->getMethods());
-        $this->assertSame(['var' => 'var', 'matchedRule' => 'matchedRule'], $rewrites[0]->getPrefixedToUnprefixedQueryVariablesMap());
-        $this->assertSame(['var', 'matchedRule'], $rewrites[0]->getQueryVariables());
-        $this->assertSame(
-            ['^first$' => 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd'],
-            $rewrites[0]->getRewriteRules()
-        );
         // @todo
         // $this->assertSame(
         //     [],
@@ -77,10 +71,6 @@ class RewriteCollectionCacheTest extends TestCase
             $rewrites[1]->getIsActiveCallback()
         );
         $this->assertSame(['POST'], $rewrites[1]->getMethods());
-        $this->assertSame(
-            ['^second$' => 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1'],
-            $rewrites[1]->getRewriteRules()
-        );
     }
 
     public function testGetWithSerializedClosures()

--- a/tests/RewriteCollectionTest.php
+++ b/tests/RewriteCollectionTest.php
@@ -43,11 +43,6 @@ class RewriteCollectionTest extends TestCase
             'someregex' => "index.php?var=value&matchedRule={$rule->getHash()}"
         ], $rewriteCollection->getRewriteRules());
 
-        // 'matchedRule' var is automatically added.
-        $this->assertSame([
-            'var' => 'var',
-            'matchedRule' => 'matchedRule',
-        ], $rewriteCollection->getPrefixedToUnprefixedQueryVariablesMap());
         $this->assertSame(['var', 'matchedRule'], $rewriteCollection->getActiveQueryVariables());
     }
 
@@ -172,12 +167,6 @@ class RewriteCollectionTest extends TestCase
         $rewriteCollection->add($two);
         $rewriteCollection->add($three);
 
-        $this->assertSame([
-            'first' => 'first',
-            'matchedRule' => 'matchedRule',
-            'third' => 'third',
-            'fourth' => 'fourth',
-        ], $rewriteCollection->getPrefixedToUnprefixedQueryVariablesMap());
         $this->assertSame(
             ['first', 'matchedRule', 'third', 'fourth'],
             $rewriteCollection->getActiveQueryVariables()
@@ -228,15 +217,6 @@ class RewriteCollectionTest extends TestCase
         $rewriteCollection->add($two);
         $rewriteCollection->add($three);
 
-        $this->assertSame(
-            [
-            'pfx_first' => 'first',
-            'pfx_matchedRule' => 'matchedRule',
-            'pfx_third' => 'third',
-            'pfx_fourth' => 'fourth',
-        ],
-            $rewriteCollection->getPrefixedToUnprefixedQueryVariablesMap()
-        );
         $this->assertSame(
             ['pfx_first', 'pfx_matchedRule', 'pfx_third', 'pfx_fourth'],
             $rewriteCollection->getActiveQueryVariables()

--- a/tests/RewriteCollectionTest.php
+++ b/tests/RewriteCollectionTest.php
@@ -327,14 +327,6 @@ class RewriteCollectionTest extends TestCase
             ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
             $rewrite->getMethods()
         );
-        $this->assertSame([
-            'var' => 'var',
-            'matchedRule' => 'matchedRule',
-        ], $rewrite->getPrefixedToUnprefixedQueryVariablesMap());
-        $this->assertSame(['var', 'matchedRule'], $rewrite->getQueryVariables());
-        $this->assertSame([
-            'someregex' => "index.php?var=value&matchedRule={$matchedRule}"
-        ], $rewrite->getRewriteRules());
         $this->assertCount(1, $rewrite->getRules());
 
         $collection = new RewriteCollection();

--- a/tests/RewriteRuleTest.php
+++ b/tests/RewriteRuleTest.php
@@ -37,6 +37,10 @@ class RewriteRuleTest extends TestCase
             'var' => 'value',
             'matchedRule' => $rule->getHash(),
         ], $rule->getQueryArray());
+        $this->assertSame([
+            'var' => 'var',
+            'matchedRule' => 'matchedRule',
+        ], $rule->getQueryVariables());
     }
 
     public function testGettersWithPrefix()
@@ -56,6 +60,10 @@ class RewriteRuleTest extends TestCase
             'var' => 'value',
             'matchedRule' => $rule->getHash(),
         ], $rule->getQueryArray());
+        $this->assertSame([
+            'pfx_var' => 'var',
+            'pfx_matchedRule' => 'matchedRule',
+        ], $rule->getQueryVariables());
     }
 
     public function testQueryWithoutLeadingIndexPhp()

--- a/tests/RewriteRuleTest.php
+++ b/tests/RewriteRuleTest.php
@@ -28,15 +28,7 @@ class RewriteRuleTest extends TestCase
         $rule = new RewriteRule('someregex', 'index.php?var=value');
 
         $this->assertSame(md5('someregex'), $rule->getHash());
-        $this->assertSame([
-            'var' => 'value',
-            'matchedRule' => $rule->getHash(),
-        ], $rule->getPrefixedQueryArray());
         $this->assertSame("index.php?var=value&matchedRule={$rule->getHash()}", $rule->getQuery());
-        $this->assertSame([
-            'var' => 'value',
-            'matchedRule' => $rule->getHash(),
-        ], $rule->getQueryArray());
         $this->assertSame([
             'var' => 'var',
             'matchedRule' => 'matchedRule',
@@ -48,18 +40,10 @@ class RewriteRuleTest extends TestCase
         $rule = new RewriteRule('someregex', 'index.php?var=value', 'pfx_');
 
         $this->assertSame(md5('someregex'), $rule->getHash());
-        $this->assertSame([
-            'pfx_var' => 'value',
-            'pfx_matchedRule' => $rule->getHash(),
-        ], $rule->getPrefixedQueryArray());
         $this->assertSame(
             "index.php?pfx_var=value&pfx_matchedRule={$rule->getHash()}",
             $rule->getQuery()
         );
-        $this->assertSame([
-            'var' => 'value',
-            'matchedRule' => $rule->getHash(),
-        ], $rule->getQueryArray());
         $this->assertSame([
             'pfx_var' => 'var',
             'pfx_matchedRule' => 'matchedRule',

--- a/tests/RewriteTest.php
+++ b/tests/RewriteTest.php
@@ -6,11 +6,26 @@ namespace ToyWpRouting\Tests;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use ToyWpRouting\DefaultInvocationStrategy;
+use ToyWpRouting\InvocationStrategyInterface;
 use ToyWpRouting\Rewrite;
 use ToyWpRouting\RewriteRule;
 
 class RewriteTest extends TestCase
 {
+    public function testGetInvocationStrategyDefault()
+    {
+        $rewrite = new Rewrite(
+            ['GET'],
+            [new RewriteRule('someregex', 'some=query')],
+            'somehandler'
+        );
+
+        $this->assertInstanceOf(
+            DefaultInvocationStrategy::class,
+            $rewrite->getInvocationStrategy()
+        );
+    }
     public function testGetters()
     {
         $rules = [new RewriteRule('someregex', 'index.php?var=value')];
@@ -21,6 +36,47 @@ class RewriteTest extends TestCase
         $this->assertNull($rewrite->getIsActiveCallback());
         $this->assertSame(['GET'], $rewrite->getMethods());
         $this->assertSame($rules, $rewrite->getRules());
+    }
+
+    public function testHandle()
+    {
+        $rewrite = new Rewrite(
+            ['GET'],
+            [new RewriteRule('someregex', 'some=query')],
+            'somehandler'
+        );
+
+        $invocationStrategy = $this->createMock(InvocationStrategyInterface::class);
+        $invocationStrategy->expects($this->once())
+            ->method('withAdditionalContext')
+            ->with(['queryVars' => ['varone' => 'valone', 'vartwo' => 'valtwo']])
+            ->willReturn($invocationStrategy);
+        $invocationStrategy->expects($this->once())
+            ->method('invokeHandler')
+            ->with($rewrite);
+
+        $rewrite->setInvocationStrategy($invocationStrategy);
+
+        $rewrite->handle(['varone' => 'valone', 'vartwo' => 'valtwo']);
+    }
+
+    public function testIsActive()
+    {
+        $rewrite = new Rewrite(
+            ['GET'],
+            [new RewriteRule('someregex', 'some=query')],
+            'somehandler',
+        );
+
+        $invocationStrategy = $this->createMock(InvocationStrategyInterface::class);
+        $invocationStrategy->expects($this->once())
+            ->method('invokeIsActiveCallback')
+            ->with($rewrite)
+            ->willReturn(true);
+
+        $rewrite->setInvocationStrategy($invocationStrategy);
+
+        $rewrite->isActive();
     }
 
     public function testMapQueryVariable()

--- a/tests/RouteCollectionTest.php
+++ b/tests/RouteCollectionTest.php
@@ -15,8 +15,8 @@ class RouteCollectionTest extends TestCase
     public function testAdd()
     {
         $collection = new RouteCollection();
-        $collection->add(['GET'], 'someroutestring', function () {
-        });
+        $collection->add(new Route(['GET'], 'someroutestring', function () {
+        }));
 
         $route = $collection->getRoutes()[0];
 
@@ -34,17 +34,8 @@ class RouteCollectionTest extends TestCase
 
         $collection = new RouteCollection();
         $collection->lock();
-        $collection->add(['GET'], 'someroutestring', function () {
-        });
-    }
-
-    public function testAddWithPrefix()
-    {
-        $collection = new RouteCollection('pfx_');
-        $collection->add(['GET'], 'someroutestring', function () {
-        });
-
-        $this->assertSame('pfx_', $collection->getRoutes()[0]->getPrefix());
+        $collection->add(new Route(['GET'], 'someroutestring', function () {
+        }));
     }
 
     public function testIsLocked()
@@ -97,5 +88,14 @@ class RouteCollectionTest extends TestCase
         $collection->put('someroutestring', function () {
         });
         $this->assertSame(['PUT'], $collection->getRoutes()[0]->getMethods());
+    }
+
+    public function testShorthandMethodsWithPrefix()
+    {
+        $collection = new RouteCollection('pfx_');
+        $collection->get('someroutestring', function () {
+        });
+
+        $this->assertSame('pfx_', $collection->getRoutes()[0]->getPrefix());
     }
 }

--- a/tests/RouteConverterTest.php
+++ b/tests/RouteConverterTest.php
@@ -22,17 +22,8 @@ class RouteConverterTest extends TestCase
         // Redundant due to typing in RewriteCollection...
         $this->assertInstanceOf(RewriteInterface::class, $rewrite);
 
-        $this->assertSame(
-            ['^someroutestring$' => 'index.php?matchedRule=' . md5('^someroutestring$')],
-            $rewrite->getRewriteRules()
-        );
         $this->assertSame(['GET'], $rewrite->getMethods());
         $this->assertSame('somehandler', $rewrite->getHandler());
-        $this->assertSame(['matchedRule'], $rewrite->getQueryVariables());
-        $this->assertSame(
-            ['matchedRule' => 'matchedRule'],
-            $rewrite->getPrefixedToUnprefixedQueryVariablesMap()
-        );
     }
 
     public function testConvertCollection()
@@ -92,10 +83,8 @@ class RouteConverterTest extends TestCase
 
         $rewrite = (new RouteConverter())->convert($route);
 
-        $this->assertSame([
-            '^someroute$' => 'index.php?matchedRule=' . md5('^someroute$'),
-            '^someroutestring$' => 'index.php?matchedRule=' . md5('^someroutestring$'),
-        ], $rewrite->getRewriteRules());
+        $this->assertSame('^someroute$', $rewrite->getRules()[0]->getRegex());
+        $this->assertSame('^someroutestring$', $rewrite->getRules()[1]->getRegex());
     }
 
     public function testConvertWithPrefix()
@@ -106,6 +95,9 @@ class RouteConverterTest extends TestCase
 
         $rewrite = (new RouteConverter())->convert($route);
 
-        $this->assertSame(['pfx_string', 'pfx_matchedRule'], $rewrite->getQueryVariables());
+        $this->assertSame(
+            ['pfx_string', 'pfx_matchedRule'],
+            array_keys($rewrite->getRules()[0]->getQueryVariables())
+        );
     }
 }

--- a/tests/SupportTest.php
+++ b/tests/SupportTest.php
@@ -53,6 +53,9 @@ class SupportTest extends TestCase
 
     public function testIsValidMethodsList()
     {
+        // False for empty array.
+        $this->assertFalse(Support::isValidMethodsList([]));
+
         // Full list of valid methods.
         $this->assertTrue(Support::isValidMethodsList(
             ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT']

--- a/tests/SupportTest.php
+++ b/tests/SupportTest.php
@@ -28,12 +28,30 @@ class SupportTest extends TestCase
         );
     }
 
+    public function testApplyPrefixToKeysWithEmptyPrefix()
+    {
+        // @todo Ideally we would be able to test not just that this works but that it isbailing early.
+        $value = ['one' => 'two', 'three' => 'four', 'five' => 'six'];
+        $prefix = '';
+
+        $this->assertSame($value, Support::applyPrefixToKeys($value, $prefix));
+    }
+
     public function testApplyPrefixWhenStringIsAlreadyPrefixed()
     {
         $prefixedValue = 'pfx_irrelevant';
         $prefix = 'pfx_';
 
         $this->assertSame('pfx_irrelevant', Support::applyPrefix($prefixedValue, $prefix));
+    }
+
+    public function testApplyPrefixWithEmptyPrefix()
+    {
+        // @todo Ideally we would be able to test not just that this works but that it isbailing early.
+        $value = 'irrelevant';
+        $prefix = '';
+
+        $this->assertSame($value, Support::applyPrefix($value, $prefix));
     }
 
     // @todo test with empty input

--- a/tests/fixtures/rewrite-cache-serialized-closures.php
+++ b/tests/fixtures/rewrite-cache-serialized-closures.php
@@ -12,8 +12,6 @@ return new class extends \ToyWpRouting\RewriteCollection
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  '^regex$' => 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'val',
   'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
@@ -24,13 +22,10 @@ return new class extends \ToyWpRouting\RewriteCollection
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
-), static function () {}, array (
+), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), array (
-  0 => 'pfx_var',
-  1 => 'pfx_matchedRule',
-), static function () {});
+), static function () {}, static function () {});
 $this->rewrites->attach($rewrite0);
 
         $this->rewriteRules = array (

--- a/tests/fixtures/rewrite-cache-serialized-closures.php
+++ b/tests/fixtures/rewrite-cache-serialized-closures.php
@@ -20,6 +20,9 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'var' => 'val',
   'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
+), array (
+  'pfx_var' => 'var',
+  'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),
 ), static function () {}, array (
   'pfx_var' => 'var',

--- a/tests/fixtures/rewrite-cache-serialized-closures.php
+++ b/tests/fixtures/rewrite-cache-serialized-closures.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
-return new class extends \ToyWpRouting\RewriteCollection
-{
-    public function __construct()
+return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null) {
+    return new class($invocationStrategy) extends \ToyWpRouting\RewriteCollection
     {
-        parent::__construct('pfx_');
+        protected bool $locked = true;
 
-        $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
+        public function __construct(?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null)
+        {
+            parent::__construct('pfx_', $invocationStrategy);
+
+            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
@@ -19,25 +22,7 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
-), static function () {}, static function () {});
-$this->rewrites->attach($rewrite0);
-
-        $this->rewriteRules = array (
-  '^regex$' => 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb',
-);
-        $this->queryVariables = array (
-  'pfx_var' => 'var',
-  'pfx_matchedRule' => 'matchedRule',
-);
-
-        $this->rewritesByRegexHashAndMethod = array (
-  'e8362b7488c4e1a7eee5ff88b032f6eb' => 
-  array (
-    'GET' => $rewrite0,
-    'HEAD' => $rewrite0,
-  ),
-);
-
-        $this->locked = true;
-    }
+), $this->invocationStrategy, static function () {}, static function () {}));
+        }
+    };
 };

--- a/tests/fixtures/rewrite-cache-serialized-closures.php
+++ b/tests/fixtures/rewrite-cache-serialized-closures.php
@@ -12,13 +12,7 @@ return new class extends \ToyWpRouting\RewriteCollection
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'pfx_var' => 'val',
-  'pfx_matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
-  'var' => 'val',
-  'matchedRule' => 'e8362b7488c4e1a7eee5ff88b032f6eb',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/fixtures/rewrite-cache-serialized-closures.php
+++ b/tests/fixtures/rewrite-cache-serialized-closures.php
@@ -11,11 +11,11 @@ return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy 
         {
             parent::__construct('pfx_', $invocationStrategy);
 
-            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+            $this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('e8362b7488c4e1a7eee5ff88b032f6eb', 'index.php?pfx_var=val&pfx_matchedRule=e8362b7488c4e1a7eee5ff88b032f6eb', array (
   'pfx_var' => 'var',
   'pfx_matchedRule' => 'matchedRule',
 ), '^regex$'),

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -12,8 +12,6 @@ return new class extends \ToyWpRouting\RewriteCollection
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  '^first$' => 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd',
-), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('9f79cebcf1735d5eaefeee8dbc7316dd', array (
   'var' => 'first',
   'matchedRule' => '9f79cebcf1735d5eaefeee8dbc7316dd',
@@ -24,18 +22,13 @@ return new class extends \ToyWpRouting\RewriteCollection
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^first$'),
-), 'firsthandler', array (
+), array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
-), array (
-  0 => 'var',
-  1 => 'matchedRule',
-), NULL);
+), 'firsthandler', NULL);
 $this->rewrites->attach($rewrite0);
 $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
-), array (
-  '^second$' => 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1',
 ), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', array (
   'var' => 'second',
@@ -47,13 +40,10 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^second$'),
-), 'secondhandler', array (
+), array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
-), array (
-  0 => 'var',
-  1 => 'matchedRule',
-), 'secondisactivecallback');
+), 'secondhandler', 'secondisactivecallback');
 $this->rewrites->attach($rewrite1);
 
         $this->rewriteRules = array (

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -11,11 +11,11 @@ return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy 
         {
             parent::__construct('', $invocationStrategy);
 
-            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+            $this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('9f79cebcf1735d5eaefeee8dbc7316dd', 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('9f79cebcf1735d5eaefeee8dbc7316dd', 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd', array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^first$'),
@@ -23,10 +23,10 @@ return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy 
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), $this->invocationStrategy, 'firsthandler', NULL));
-$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
+$this->rewrites->attach(new \ToyWpRouting\Compiler\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
+  0 => new \ToyWpRouting\Compiler\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^second$'),

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -10,6 +10,7 @@ return new class extends \ToyWpRouting\RewriteCollection
 
         $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
+  1 => 'HEAD',
 ), array (
   '^first$' => 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd',
 ), array (
@@ -62,6 +63,7 @@ $this->rewrites->attach($rewrite1);
   '9f79cebcf1735d5eaefeee8dbc7316dd' => 
   array (
     'GET' => $rewrite0,
+    'HEAD' => $rewrite0,
   ),
   '3cf5d427e03a68a3881d2d68a86b64f1' => 
   array (

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -12,13 +12,7 @@ return new class extends \ToyWpRouting\RewriteCollection
   0 => 'GET',
   1 => 'HEAD',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('9f79cebcf1735d5eaefeee8dbc7316dd', array (
-  'var' => 'first',
-  'matchedRule' => '9f79cebcf1735d5eaefeee8dbc7316dd',
-), 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd', array (
-  'var' => 'first',
-  'matchedRule' => '9f79cebcf1735d5eaefeee8dbc7316dd',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('9f79cebcf1735d5eaefeee8dbc7316dd', 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd', array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^first$'),
@@ -30,13 +24,7 @@ $this->rewrites->attach($rewrite0);
 $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
-  0 => new \ToyWpRouting\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', array (
-  'var' => 'second',
-  'matchedRule' => '3cf5d427e03a68a3881d2d68a86b64f1',
-), 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
-  'var' => 'second',
-  'matchedRule' => '3cf5d427e03a68a3881d2d68a86b64f1',
-), array (
+  0 => new \ToyWpRouting\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
 ), '^second$'),

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -20,6 +20,9 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd', array (
   'var' => 'first',
   'matchedRule' => '9f79cebcf1735d5eaefeee8dbc7316dd',
+), array (
+  'var' => 'var',
+  'matchedRule' => 'matchedRule',
 ), '^first$'),
 ), 'firsthandler', array (
   'var' => 'var',
@@ -40,6 +43,9 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
 ), 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
   'var' => 'second',
   'matchedRule' => '3cf5d427e03a68a3881d2d68a86b64f1',
+), array (
+  'var' => 'var',
+  'matchedRule' => 'matchedRule',
 ), '^second$'),
 ), 'secondhandler', array (
   'var' => 'var',

--- a/tests/fixtures/rewrite-cache.php
+++ b/tests/fixtures/rewrite-cache.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
-return new class extends \ToyWpRouting\RewriteCollection
-{
-    public function __construct()
+return function (?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null) {
+    return new class($invocationStrategy) extends \ToyWpRouting\RewriteCollection
     {
-        parent::__construct('');
+        protected bool $locked = true;
 
-        $rewrite0 = new \ToyWpRouting\OptimizedRewrite(array (
+        public function __construct(?\ToyWpRouting\InvocationStrategyInterface $invocationStrategy = null)
+        {
+            parent::__construct('', $invocationStrategy);
+
+            $this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'GET',
   1 => 'HEAD',
 ), array (
@@ -19,9 +22,8 @@ return new class extends \ToyWpRouting\RewriteCollection
 ), array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
-), 'firsthandler', NULL);
-$this->rewrites->attach($rewrite0);
-$rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
+), $this->invocationStrategy, 'firsthandler', NULL));
+$this->rewrites->attach(new \ToyWpRouting\OptimizedRewrite(array (
   0 => 'POST',
 ), array (
   0 => new \ToyWpRouting\OptimizedRewriteRule('3cf5d427e03a68a3881d2d68a86b64f1', 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1', array (
@@ -31,30 +33,7 @@ $rewrite1 = new \ToyWpRouting\OptimizedRewrite(array (
 ), array (
   'var' => 'var',
   'matchedRule' => 'matchedRule',
-), 'secondhandler', 'secondisactivecallback');
-$this->rewrites->attach($rewrite1);
-
-        $this->rewriteRules = array (
-  '^first$' => 'index.php?var=first&matchedRule=9f79cebcf1735d5eaefeee8dbc7316dd',
-  '^second$' => 'index.php?var=second&matchedRule=3cf5d427e03a68a3881d2d68a86b64f1',
-);
-        $this->queryVariables = array (
-  'var' => 'var',
-  'matchedRule' => 'matchedRule',
-);
-
-        $this->rewritesByRegexHashAndMethod = array (
-  '9f79cebcf1735d5eaefeee8dbc7316dd' => 
-  array (
-    'GET' => $rewrite0,
-    'HEAD' => $rewrite0,
-  ),
-  '3cf5d427e03a68a3881d2d68a86b64f1' => 
-  array (
-    'POST' => $rewrite1,
-  ),
-);
-
-        $this->locked = true;
-    }
+), $this->invocationStrategy, 'secondhandler', 'secondisactivecallback'));
+        }
+    };
 };


### PR DESCRIPTION
Switches to lazy initialization of all computed props in RewriteCollection. This ensures we aren't looping over the same data multiple times to compute different props.

Also stops tracking rewrite data in multiple locations - moves everything up to RewriteCollection.

Finally - eliminates the `filter` method on RewriteCollection which was previously used to create a second collection instance for active rewrites. Instead we compute individual active* props and store them on the main collection instance.

Naive benchmarks show performance increases across the board from as low as ~5% improvement for 10 cached rewrites to nearly ~50% improvement with 100 uncached rewrites.

We can probably improve cached performance even more in cases where we know that either active callbacks will not be used or active conditions can be evaluated at cache time. This should be introduced as a second compiler class in a separate PR.