### PR TITLE
Responders

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -21,6 +21,7 @@ return (new Config())
 			->in(__DIR__)
 			->exclude([
 				'bin',
+				'scratch',
 				'templates',
 				'tests/fixtures',
 			])

--- a/README.md
+++ b/README.md
@@ -102,18 +102,20 @@ $routes->get('api/products', function () {
 
 Responses are sent using `wp_send_json_success` or `wp_send_json_error` depending on the status code, so data will be available at `response.data`.
 
-### ToyWpRouting\Responder\NotFoundResponder
+### ToyWpRouting\Responder\QueryResponder
 ```php
-$routes->get('api/products/{product}', function ($attrs) {
-  $product = getProductById($attrs['product']);
+$routes->get('products/random[/{count}]', function ($attrs) {
+  $count = min(max((int) ($attrs['count'] ?? 5), 1), 10);
 
-  if (! $product) {
-    return new NotFoundResponder();
-  }
-
-  return new JsonResponder($product);
+  return new QueryResponder([
+    'post_type' => 'pfx_product',
+    'orderby' => 'rand',
+    'posts_per_page' => $count,
+  ]);
 });
 ```
+
+Query variables are applied on the `parse_request` hook, before the main query is run.
 
 ### ToyWpRouting\Responder\RedirectResponder
 ```php

--- a/src/Orchestrator.php
+++ b/src/Orchestrator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace ToyWpRouting;
 
 use RuntimeException;
+use ToyWpRouting\Responder\MethodNotAllowedResponder;
+use ToyWpRouting\Responder\ResponderInterface;
 
 class Orchestrator
 {

--- a/src/Responder/Concerns/ModifiesResponseHeaders.php
+++ b/src/Responder/Concerns/ModifiesResponseHeaders.php
@@ -51,7 +51,7 @@ trait ModifiesResponseHeaders
     public function withStatusCode(int $status): self
     {
         if ($status < 100 || $status >= 600) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException('Invalid status code - must be between 100 and 599');
         }
 
         $this->modifiesResponseHeadersData['status'] = $status;

--- a/src/Responder/Concerns/ModifiesResponseHeaders.php
+++ b/src/Responder/Concerns/ModifiesResponseHeaders.php
@@ -48,7 +48,7 @@ trait ModifiesResponseHeaders
         return $this;
     }
 
-    public function withStatus(int $status): self
+    public function withStatusCode(int $status): self
     {
         if ($status < 100 || $status >= 600) {
             throw new InvalidArgumentException('@todo');

--- a/src/Responder/Concerns/ModifiesResponseHeaders.php
+++ b/src/Responder/Concerns/ModifiesResponseHeaders.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 // @todo status?
 trait ModifiesResponseHeaders

--- a/src/Responder/Concerns/ModifiesResponseHeaders.php
+++ b/src/Responder/Concerns/ModifiesResponseHeaders.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+// @todo status?
+trait ModifiesResponseHeaders
+{
+    protected array $modifiesResponseHeadersData = [
+        'headers' => [],
+    ];
+
+    public function withHeader(string $key, string $value): self
+    {
+        $this->modifiesResponseHeadersData['headers'][$key] = $value;
+
+        return $this;
+    }
+
+    public function withHeaders(array $headers): self
+    {
+        $this->modifiesResponseHeadersData['headers'] = [];
+
+        foreach ($headers as $key => $value) {
+            $this->withHeader($key, $value);
+        }
+
+        return $this;
+    }
+
+    protected function initializeModifiesResponseHeaders(): void
+    {
+        $this->addFilter('wp_headers', function ($headers) {
+            // @todo Handle multiple headers with same key?
+            // @todo Return our array of headers if ! is_array($headers)?
+            if (is_array($headers) && ! empty($this->modifiesResponseHeadersData['headers'])) {
+                $headers = array_merge($headers, $this->modifiesResponseHeadersData['headers']);
+            }
+
+            return $headers;
+        });
+    }
+}

--- a/src/Responder/Concerns/ModifiesResponseHtml.php
+++ b/src/Responder/Concerns/ModifiesResponseHtml.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 // @todo ModifiesResponseTemplateHtml? enqueue scripts and style? 404 preempt?
 trait ModifiesResponseHtml

--- a/src/Responder/Concerns/ModifiesResponseHtml.php
+++ b/src/Responder/Concerns/ModifiesResponseHtml.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace ToyWpRouting\Responder\Concerns;
 
-// @todo ModifiesResponseTemplateHtml? enqueue scripts and style? 404 preempt?
+// @todo enqueue scripts and style? 404 preempt?
 trait ModifiesResponseHtml
 {
     protected array $modifiesResponseHtmlData = [
+        'body' => null,
         'bodyClasses' => [],
         'title' => null,
         'template' => null,
     ];
+
+    public function withBody(string $body): self
+    {
+        $this->modifiesResponseHtmlData['body'] = $body;
+
+        return $this;
+    }
 
     public function withBodyClass(string $bodyClass): self
     {
@@ -62,11 +70,34 @@ trait ModifiesResponseHtml
         });
 
         $this->addFilter('template_include', function ($template) {
-            if (is_string($this->modifiesResponseHtmlData['template'])) {
-                return $this->modifiesResponseHtmlData['template'];
+            if (! is_string($this->modifiesResponseHtmlData['template'])) {
+                return $template;
             }
 
-            return $template;
+            return $this->modifiesResponseHtmlData['template'];
+        });
+
+        // @todo Merge all template_include functionality?
+        $this->addFilter('template_include', function ($template) {
+            if (! is_string($this->modifiesResponseHtmlData['body'])) {
+                return $template;
+            }
+
+            echo $this->modifiesResponseHtmlData['body'];
+
+            return dirname(__DIR__, 3) . '/templates/blank.php';
+        });
+
+        $this->addConflictCheck(function () {
+            // template and json? redirect?
+            // body and json? redirect?
+
+            if (
+                is_string($this->modifiesResponseHtmlData['body'])
+                && is_string($this->modifiesResponseHtmlData['template'])
+            ) {
+                return 'Cannot set both response body and template';
+            }
         });
     }
 

--- a/src/Responder/Concerns/ModifiesResponseHtml.php
+++ b/src/Responder/Concerns/ModifiesResponseHtml.php
@@ -8,18 +8,10 @@ namespace ToyWpRouting\Responder\Concerns;
 trait ModifiesResponseHtml
 {
     protected array $modifiesResponseHtmlData = [
-        'body' => null,
         'bodyClasses' => [],
         'title' => null,
         'template' => null,
     ];
-
-    public function withBody(string $body): self
-    {
-        $this->modifiesResponseHtmlData['body'] = $body;
-
-        return $this;
-    }
 
     public function withBodyClass(string $bodyClass): self
     {
@@ -77,28 +69,7 @@ trait ModifiesResponseHtml
             return $this->modifiesResponseHtmlData['template'];
         });
 
-        // @todo Merge all template_include functionality?
-        $this->addFilter('template_include', function ($template) {
-            if (! is_string($this->modifiesResponseHtmlData['body'])) {
-                return $template;
-            }
-
-            echo $this->modifiesResponseHtmlData['body'];
-
-            return dirname(__DIR__, 3) . '/templates/blank.php';
-        });
-
-        $this->addConflictCheck(function () {
-            // template and json? redirect?
-            // body and json? redirect?
-
-            if (
-                is_string($this->modifiesResponseHtmlData['body'])
-                && is_string($this->modifiesResponseHtmlData['template'])
-            ) {
-                return 'Cannot set both response body and template';
-            }
-        });
+        // @todo All conflict with json? redirect?
     }
 
     protected function isModifyingResponseHtmlTemplate(): bool

--- a/src/Responder/Concerns/ModifiesResponseHtml.php
+++ b/src/Responder/Concerns/ModifiesResponseHtml.php
@@ -131,11 +131,37 @@ trait ModifiesResponseHtml
             return $this->modifiesResponseHtmlData['template'];
         });
 
-        // @todo All conflict with json? redirect? body?
+        $this->addConflictCheck(function () {
+            if (! $this->isModifyingResponseHtml()) {
+                return;
+            }
+
+            if (method_exists($this, 'isSendingJsonResponse') && $this->isSendingJsonResponse()) {
+                return 'Cannot modify response HTML and send JSON response at the same time';
+            }
+
+            if (
+                method_exists($this, 'isSendingDirectResponse')
+                && $this->isSendingDirectResponse()
+            ) {
+                return 'Cannot modify response HTML and send direct response at the same time';
+            }
+
+            if (
+                method_exists($this, 'isSendingRedirectResponse')
+                && $this->isSendingRedirectResponse()
+            ) {
+                return 'Cannot modify response HTML and send redirect response at the same time';
+            }
+        });
     }
 
-    protected function isModifyingResponseHtmlTemplate(): bool
+    protected function isModifyingResponseHtml(): bool
     {
-        return is_string($this->modifiesResponseHtmlData['template']);
+        return ! empty($this->modifiesResponseHtmlData['bodyClasses'])
+            || ! empty($this->modifiesResponseHtmlData['enqueuedScripts'])
+            || ! empty($this->modifiesResponseHtmlData['enqueuedStyles'])
+            || is_string($this->modifiesResponseHtmlData['title'])
+            || is_string($this->modifiesResponseHtmlData['template']);
     }
 }

--- a/src/Responder/Concerns/ModifiesResponseHtml.php
+++ b/src/Responder/Concerns/ModifiesResponseHtml.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+// @todo ModifiesResponseTemplateHtml? enqueue scripts and style? 404 preempt?
+trait ModifiesResponseHtml
+{
+    protected array $modifiesResponseHtmlData = [
+        'bodyClasses' => [],
+        'title' => null,
+        'template' => null,
+    ];
+
+    public function withBodyClass(string $bodyClass): self
+    {
+        $this->modifiesResponseHtmlData['bodyClasses'][] = $bodyClass;
+
+        return $this;
+    }
+
+    public function withBodyClasses(array $bodyClasses): self
+    {
+        $this->modifiesResponseHtmlData['bodyClasses'] = array_values(
+            (fn (string ...$bodyClasses) => $bodyClasses)(...$bodyClasses)
+        );
+
+        return $this;
+    }
+
+    public function withTemplate(string $templatePath): self
+    {
+        $this->modifiesResponseHtmlData['template'] = $templatePath;
+
+        return $this;
+    }
+
+    public function withTitle(string $title): self
+    {
+        $this->modifiesResponseHtmlData['title'] = $title;
+
+        return $this;
+    }
+
+    protected function initializeModifiesResponseHtml(): void
+    {
+        $this->addFilter('body_class', function ($classes) {
+            if (is_array($classes) && ! empty($this->modifiesResponseHtmlData['bodyClasses'])) {
+                $classes = array_merge($classes, $this->modifiesResponseHtmlData['bodyClasses']);
+            }
+
+            return $classes;
+        });
+
+        $this->addFilter('document_title_parts', function ($parts) {
+            if (is_array($parts) && is_string($this->modifiesResponseHtmlData['title'])) {
+                $parts['title'] = $this->modifiesResponseHtmlData['title'];
+            }
+
+            return $parts;
+        });
+
+        $this->addFilter('template_include', function ($template) {
+            if (is_string($this->modifiesResponseHtmlData['template'])) {
+                return $this->modifiesResponseHtmlData['template'];
+            }
+
+            return $template;
+        });
+    }
+
+    protected function isModifyingResponseHtmlTemplate(): bool
+    {
+        return is_string($this->modifiesResponseHtmlData['template']);
+    }
+}

--- a/src/Responder/Concerns/ModifiesWpParameters.php
+++ b/src/Responder/Concerns/ModifiesWpParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 use WP;
 

--- a/src/Responder/Concerns/ModifiesWpParameters.php
+++ b/src/Responder/Concerns/ModifiesWpParameters.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use WP;
+
+trait ModifiesWpParameters
+{
+    protected array $modifiesWpParametersData = [
+        'queryVariables' => [],
+    ];
+
+    public function withPreLoopQueryVariable(string $key, $value): self
+    {
+        $this->modifiesWpParametersData['queryVariables'][$key] = $value;
+
+        return $this;
+    }
+
+    public function withPreLoopQueryVariables(array $queryVariables): self
+    {
+        $this->modifiesWpParametersData['queryVariables'] = [];
+
+        foreach ($queryVariables as $key => $value) {
+            $this->withPreLoopQueryVariable($key, $value);
+        }
+
+        return $this;
+    }
+
+    protected function initializeModifiesWpParameters(): void
+    {
+        $this->addAction('parse_request', function (WP $wp) {
+            foreach ($this->modifiesWpParametersData['queryVariables'] as $key => $value) {
+                $wp->set_query_var($key, $value);
+            }
+        });
+    }
+}

--- a/src/Responder/Concerns/ModifiesWpParameters.php
+++ b/src/Responder/Concerns/ModifiesWpParameters.php
@@ -10,7 +10,24 @@ trait ModifiesWpParameters
 {
     protected array $modifiesWpParametersData = [
         'queryVariables' => [],
+        'overwrite' => false,
     ];
+
+    public function withAdditionalPreLoopQueryVariables(array $queryVariables): self
+    {
+        foreach ($queryVariables as $key => $value) {
+            $this->withPreLoopQueryVariable($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function withExistingPreLoopQueryVariablesOverwritten(): self
+    {
+        $this->modifiesWpParametersData['overwrite'] = true;
+
+        return $this;
+    }
 
     public function withPreLoopQueryVariable(string $key, $value): self
     {
@@ -33,8 +50,16 @@ trait ModifiesWpParameters
     protected function initializeModifiesWpParameters(): void
     {
         $this->addAction('parse_request', function (WP $wp) {
-            foreach ($this->modifiesWpParametersData['queryVariables'] as $key => $value) {
-                $wp->set_query_var($key, $value);
+            if (empty($this->modifiesWpParametersData['queryVariables'])) {
+                return;
+            }
+
+            if ($this->modifiesWpParametersData['overwrite']) {
+                $wp->query_vars = $this->modifiesWpParametersData['queryVariables'];
+            } else {
+                foreach ($this->modifiesWpParametersData['queryVariables'] as $key => $value) {
+                    $wp->set_query_var($key, $value);
+                }
             }
         });
     }

--- a/src/Responder/Concerns/ModifiesWpParameters.php
+++ b/src/Responder/Concerns/ModifiesWpParameters.php
@@ -13,35 +13,35 @@ trait ModifiesWpParameters
         'overwrite' => false,
     ];
 
-    public function withAdditionalPreLoopQueryVariables(array $queryVariables): self
+    public function withAdditionalRequestVariables(array $queryVariables): self
     {
         foreach ($queryVariables as $key => $value) {
-            $this->withPreLoopQueryVariable($key, $value);
+            $this->withRequestVariable($key, $value);
         }
 
         return $this;
     }
 
-    public function withExistingPreLoopQueryVariablesOverwritten(): self
+    public function withExistingRequestVariablesOverwritten(): self
     {
         $this->modifiesWpParametersData['overwrite'] = true;
 
         return $this;
     }
 
-    public function withPreLoopQueryVariable(string $key, $value): self
+    public function withRequestVariable(string $key, $value): self
     {
         $this->modifiesWpParametersData['queryVariables'][$key] = $value;
 
         return $this;
     }
 
-    public function withPreLoopQueryVariables(array $queryVariables): self
+    public function withRequestVariables(array $queryVariables): self
     {
         $this->modifiesWpParametersData['queryVariables'] = [];
 
         foreach ($queryVariables as $key => $value) {
-            $this->withPreLoopQueryVariable($key, $value);
+            $this->withRequestVariable($key, $value);
         }
 
         return $this;

--- a/src/Responder/Concerns/ModifiesWpQueryParameters.php
+++ b/src/Responder/Concerns/ModifiesWpQueryParameters.php
@@ -43,11 +43,37 @@ trait ModifiesWpQueryParameters
             'is_post_type_archive' => false,
         ],
         'queryVariables' => [],
+        'overwrite' => false,
     ];
+
+    public function withAdditionalQueryFlags(array $queryFlags): self
+    {
+        foreach ($queryFlags as $key => $value) {
+            $this->withQueryFlag($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function withAdditionalQueryVariables(array $queryVariables): self
+    {
+        foreach ($queryVariables as $key => $value) {
+            $this->withQueryVariable($key, $value);
+        }
+
+        return $this;
+    }
 
     public function withAllQueryFlagsReset(): self
     {
         $this->modifiesWpQueryParametersData['flags'] = $this->modifiesWpQueryParametersData['flagsInitialState'];
+
+        return $this;
+    }
+
+    public function withExistingQueryVariablesOverwritten(): self
+    {
+        $this->modifiesWpQueryParametersData['overwrite'] = true;
 
         return $this;
     }
@@ -99,8 +125,16 @@ trait ModifiesWpQueryParameters
                 $wpQuery->{$key} = $value;
             }
 
-            foreach ($this->modifiesWpQueryParametersData['queryVariables'] as $key => $value) {
-                $wpQuery->query_vars[$key] = $value;
+            if (empty($this->modifiesWpQueryParametersData['queryVariables'])) {
+                return;
+            }
+
+            if ($this->modifiesWpQueryParametersData['overwrite']) {
+                $wpQuery->query_vars = $this->modifiesWpQueryParametersData['queryVariables'];
+            } else {
+                foreach ($this->modifiesWpQueryParametersData['queryVariables'] as $key => $value) {
+                    $wpQuery->query_vars[$key] = $value;
+                }
             }
         });
     }

--- a/src/Responder/Concerns/ModifiesWpQueryParameters.php
+++ b/src/Responder/Concerns/ModifiesWpQueryParameters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 use InvalidArgumentException;
 use WP_Query;

--- a/src/Responder/Concerns/ModifiesWpQueryParameters.php
+++ b/src/Responder/Concerns/ModifiesWpQueryParameters.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use InvalidArgumentException;
+use WP_Query;
+
+trait ModifiesWpQueryParameters
+{
+    protected array $modifiesWpQueryParametersData = [
+        'flags' => [],
+        'flagsInitialState' => [
+            'is_single' => false,
+            'is_preview' => false,
+            'is_page' => false,
+            'is_archive' => false,
+            'is_date' => false,
+            'is_year' => false,
+            'is_month' => false,
+            'is_day' => false,
+            'is_time' => false,
+            'is_author' => false,
+            'is_category' => false,
+            'is_tag' => false,
+            'is_tax' => false,
+            'is_search' => false,
+            'is_feed' => false,
+            'is_comment_feed' => false,
+            'is_trackback' => false,
+            'is_home' => false,
+            'is_privacy_policy' => false,
+            'is_404' => false,
+            'is_embed' => false,
+            'is_paged' => false,
+            'is_admin' => false,
+            'is_attachment' => false,
+            'is_singular' => false,
+            'is_robots' => false,
+            'is_favicon' => false,
+            'is_posts_page' => false,
+            'is_post_type_archive' => false,
+        ],
+        'queryVariables' => [],
+    ];
+
+    public function withAllQueryFlagsReset(): self
+    {
+        $this->modifiesWpQueryParametersData['flags'] = $this->modifiesWpQueryParametersData['flagsInitialState'];
+
+        return $this;
+    }
+
+    public function withQueryFlag(string $key, bool $value): self
+    {
+        if (! array_key_exists($key, $this->modifiesWpQueryParametersData['flagsInitialState'])) {
+            throw new InvalidArgumentException('@todo');
+        }
+
+        $this->modifiesWpQueryParametersData['flags'][$key] = $value;
+
+        return $this;
+    }
+
+    public function withQueryFlags(array $queryFlags): self
+    {
+        $this->modifiesWpQueryParametersData['flags'] = [];
+
+        foreach ($queryFlags as $key => $value) {
+            $this->withQueryFlag($key, $value);
+        }
+
+        return $this;
+    }
+
+    public function withQueryVariable(string $key, $value): self
+    {
+        $this->modifiesWpQueryParametersData['queryVariables'][$key] = $value;
+
+        return $this;
+    }
+
+    public function withQueryVariables(array $queryVariables): self
+    {
+        $this->modifiesWpQueryParametersData['queryVariables'] = [];
+
+        foreach ($queryVariables as $key => $value) {
+            $this->withQueryVariable($key, $value);
+        }
+
+        return $this;
+    }
+
+    protected function initializeModifiesWpQueryParameters(): void
+    {
+        $this->addAction('parse_query', function (WP_Query $wpQuery) {
+            foreach ($this->modifiesWpQueryParametersData['flags'] as $key => $value) {
+                $wpQuery->{$key} = $value;
+            }
+
+            foreach ($this->modifiesWpQueryParametersData['queryVariables'] as $key => $value) {
+                $wpQuery->query_vars[$key] = $value;
+            }
+        });
+    }
+}

--- a/src/Responder/Concerns/ModifiesWpQueryParameters.php
+++ b/src/Responder/Concerns/ModifiesWpQueryParameters.php
@@ -81,7 +81,7 @@ trait ModifiesWpQueryParameters
     public function withQueryFlag(string $key, bool $value): self
     {
         if (! array_key_exists($key, $this->modifiesWpQueryParametersData['flagsInitialState'])) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException("Cannot set unrecognized query flag \"{$key}\"");
         }
 
         $this->modifiesWpQueryParametersData['flags'][$key] = $value;

--- a/src/Responder/Concerns/SendsDirectResponses.php
+++ b/src/Responder/Concerns/SendsDirectResponses.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ToyWpRouting\Responder\Concerns;
 
 trait SendsDirectResponses
@@ -33,7 +35,10 @@ trait SendsDirectResponses
                 return;
             }
 
-            if (method_exists($this, 'isModifyingResponseHtmlTemplate') && $this->isModifyingResponseHtmlTemplate()) {
+            if (
+                method_exists($this, 'isModifyingResponseHtmlTemplate')
+                && $this->isModifyingResponseHtmlTemplate()
+            ) {
                 return 'Cannot set both response body and template';
             }
         });

--- a/src/Responder/Concerns/SendsDirectResponses.php
+++ b/src/Responder/Concerns/SendsDirectResponses.php
@@ -30,17 +30,32 @@ trait SendsDirectResponses
         });
 
         $this->addConflictCheck(function () {
-            // @todo json? redirect?
-            if (! is_string($this->sendsDirectResponses['body'])) {
+            if (! $this->isSendingDirectResponse()) {
                 return;
             }
 
             if (
-                method_exists($this, 'isModifyingResponseHtmlTemplate')
-                && $this->isModifyingResponseHtmlTemplate()
+                method_exists($this, 'isModifyingResponseHtml')
+                && $this->isModifyingResponseHtml()
             ) {
-                return 'Cannot set custom response body and with template response';
+                return 'Cannot send direct response and modify response HTML at the same time';
+            }
+
+            if (method_exists($this, 'isSendingJsonResponse') && $this->isSendingJsonResponse()) {
+                return 'Cannot send direct response and JSON response at the same time';
+            }
+
+            if (
+                method_exists($this, 'isSendingRedirectResponse')
+                && $this->isSendingRedirectResponse()
+            ) {
+                return 'Cannot send direct response and redirect response at the same time';
             }
         });
+    }
+
+    protected function isSendingDirectResponse(): bool
+    {
+        return is_string($this->sendsDirectResponses['body']);
     }
 }

--- a/src/Responder/Concerns/SendsDirectResponses.php
+++ b/src/Responder/Concerns/SendsDirectResponses.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ToyWpRouting\Responder\Concerns;
+
+trait SendsDirectResponses
+{
+    protected array $sendsDirectResponses = [
+        'body' => null,
+    ];
+
+    public function withBody(string $body): self
+    {
+        $this->sendsDirectResponses['body'] = $body;
+
+        return $this;
+    }
+
+    protected function initializeSendsDirectResponses(): void
+    {
+        $this->addFilter('template_include', function ($template) {
+            if (! is_string($this->sendsDirectResponses['body'])) {
+                return $template;
+            }
+
+            echo $this->sendsDirectResponses['body'];
+
+            return dirname(__DIR__, 3) . '/templates/blank.php';
+        });
+
+        $this->addConflictCheck(function () {
+            // @todo json? redirect?
+            if (! is_string($this->sendsDirectResponses['body'])) {
+                return;
+            }
+
+            if (method_exists($this, 'isModifyingResponseHtmlTemplate') && $this->isModifyingResponseHtmlTemplate()) {
+                return 'Cannot set both response body and template';
+            }
+        });
+    }
+}

--- a/src/Responder/Concerns/SendsDirectResponses.php
+++ b/src/Responder/Concerns/SendsDirectResponses.php
@@ -39,7 +39,7 @@ trait SendsDirectResponses
                 method_exists($this, 'isModifyingResponseHtmlTemplate')
                 && $this->isModifyingResponseHtmlTemplate()
             ) {
-                return 'Cannot set both response body and template';
+                return 'Cannot set custom response body and with template response';
             }
         });
     }

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -76,17 +76,24 @@ trait SendsJsonResponses
             }
 
             if (
-                method_exists($this, 'isModifyingResponseHtmlTemplate')
-                && $this->isModifyingResponseHtmlTemplate()
+                method_exists($this, 'isModifyingResponseHtml')
+                && $this->isModifyingResponseHtml()
             ) {
-                return 'Cannot set JSON response and template response at the same time';
+                return 'Cannot send JSON response and modify response HTML at the same time';
+            }
+
+            if (
+                method_exists($this, 'isSendingDirectResponse')
+                && $this->isSendingDirectResponse()
+            ) {
+                return 'Cannot send JSON response and direct response at the same time';
             }
 
             if (
                 method_exists($this, 'isSendingRedirectResponse')
                 && $this->isSendingRedirectResponse()
             ) {
-                return 'Cannot set JSON response and redirect response at the same time';
+                return 'Cannot send JSON response and redirect response at the same time';
             }
         });
     }

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use InvalidArgumentException;
+
+// @todo Conflicts - status
+trait SendsJsonResponses
+{
+    protected array $sendsJsonResponsesData = [
+        'hasData' => false,
+        'data' => null,
+        'options' => 0,
+        'status' => 200,
+    ];
+
+    public function withJsonData($data): self
+    {
+        $this->sendsJsonResponsesData['hasData'] = true;
+        $this->sendsJsonResponsesData['data'] = $data;
+
+        return $this;
+    }
+
+    public function withJsonOptions(int $options): self
+    {
+        $this->sendsJsonResponsesData['options'] = $options;
+
+        return $this;
+    }
+
+    public function withJsonStatusCode(int $statusCode): self
+    {
+        // 1xx responses shouldn't have a body - should we allow them here anyway?
+        if ($statusCode < 200 || ($statusCode >= 300 && $statusCode < 400) || $statusCode >= 600) {
+            throw new InvalidArgumentException('@todo');
+        }
+
+        $this->sendsJsonResponsesData['status'] = $statusCode;
+
+        return $this;
+    }
+
+    protected function initializeSendsJsonResponses(): void
+    {
+        $this->addAction('template_redirect', function () {
+            if (! $this->isSendingJsonResponse()) {
+                return;
+            }
+
+            if ($this->statusCode >= 200 && $this->statusCode < 300) {
+                wp_send_json_success($this->data, $this->statusCode, $this->options);
+            } else {
+                wp_send_json_error($this->data, $this->statusCode, $this->options);
+            }
+        });
+
+        $this->addConflictCheck(function () {
+            if (!$this->isSendingJsonResponse()) {
+                return;
+            }
+
+            if (
+                method_exists($this, 'isModifyingResponseHtmlTemplate')
+                && $this->isModifyingResponseHtmlTemplate()
+            ) {
+                return '@todo';
+            }
+
+            if (
+                method_exists($this, 'isSendingRedirectResponse')
+                && $this->isSendingRedirectResponse()
+            ) {
+                return '@todo';
+            }
+        });
+    }
+
+    protected function isSendingJsonResponse(): bool
+    {
+        return $this->sendsJsonResponsesData['hasData'];
+    }
+}

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -77,14 +77,14 @@ trait SendsJsonResponses
                 method_exists($this, 'isModifyingResponseHtmlTemplate')
                 && $this->isModifyingResponseHtmlTemplate()
             ) {
-                return '@todo';
+                return 'Cannot set JSON response and template response at the same time';
             }
 
             if (
                 method_exists($this, 'isSendingRedirectResponse')
                 && $this->isSendingRedirectResponse()
             ) {
-                return '@todo';
+                return 'Cannot set JSON response and redirect response at the same time';
             }
         });
     }

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -35,7 +35,9 @@ trait SendsJsonResponses
     {
         // 1xx responses shouldn't have a body - should we allow them here anyway?
         if ($statusCode < 200 || ($statusCode >= 300 && $statusCode < 400) || $statusCode >= 600) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException(
+                'JSON response code must be between 200 and 299 or between 400 and 599'
+            );
         }
 
         $this->sendsJsonResponsesData['status'] = $statusCode;

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 use InvalidArgumentException;
 

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -50,10 +50,21 @@ trait SendsJsonResponses
                 return;
             }
 
-            if ($this->statusCode >= 200 && $this->statusCode < 300) {
-                wp_send_json_success($this->data, $this->statusCode, $this->options);
+            if (
+                $this->sendsJsonResponsesData['status'] >= 200
+                && $this->sendsJsonResponsesData['status'] < 300
+            ) {
+                wp_send_json_success(
+                    $this->sendsJsonResponsesData['data'],
+                    $this->sendsJsonResponsesData['status'],
+                    $this->sendsJsonResponsesData['options']
+                );
             } else {
-                wp_send_json_error($this->data, $this->statusCode, $this->options);
+                wp_send_json_error(
+                    $this->sendsJsonResponsesData['data'],
+                    $this->sendsJsonResponsesData['status'],
+                    $this->sendsJsonResponsesData['options']
+                );
             }
         });
 

--- a/src/Responder/Concerns/SendsJsonResponses.php
+++ b/src/Responder/Concerns/SendsJsonResponses.php
@@ -6,7 +6,6 @@ namespace ToyWpRouting\Responder\Concerns;
 
 use InvalidArgumentException;
 
-// @todo Conflicts - status
 trait SendsJsonResponses
 {
     protected array $sendsJsonResponsesData = [
@@ -71,8 +70,16 @@ trait SendsJsonResponses
         });
 
         $this->addConflictCheck(function () {
-            if (!$this->isSendingJsonResponse()) {
+            if (! $this->isSendingJsonResponse()) {
                 return;
+            }
+
+            if (
+                method_exists($this, 'isModifyingResponseStatus')
+                && $this->isModifyingResponseStatus()
+            ) {
+                return 'Cannot set status code on JSON response via "withStatusCode" method'
+                    . ' - must use "withJsonStatusCode" method';
             }
 
             if (

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -33,7 +33,7 @@ trait SendsRedirectResponses
     public function withRedirectStatusCode(int $statusCode): self
     {
         if (! ($statusCode >= 300 && $statusCode < 400)) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException('Redirect status code must be between 300 and 399');
         }
 
         $this->sendsRedirectResponsesData['status'] = $statusCode;

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use InvalidArgumentException;
+
+// @todo Conflicts - headers contain x-redirect-by, status,
+trait SendsRedirectResponses
+{
+    protected array $sendsRedirectResponsesData = [
+        'location' => '',
+        'redirectBy' => 'WordPress',
+        'safe' => true,
+        'status' => 302,
+    ];
+
+    public function withRedirectByHeader(string $redirectBy): self
+    {
+        $this->sendsRedirectResponsesData['redirectBy'] = $redirectBy;
+
+        return $this;
+    }
+
+    public function withRedirectLocation(string $location): self
+    {
+        $this->sendsRedirectResponsesData['location'] = $location;
+
+        return $this;
+    }
+
+    public function withRedirectStatusCode(int $statusCode): self
+    {
+        if (! ($statusCode >= 300 && $statusCode < 400)) {
+            throw new InvalidArgumentException('@todo');
+        }
+
+        $this->sendsRedirectResponsesData['status'] = $statusCode;
+
+        return $this;
+    }
+
+    public function withUnsafeRedirectsAllowed(): self
+    {
+        $this->sendsRedirectResponsesData['safe'] = false;
+
+        return $this;
+    }
+
+    protected function initializeSendsRedirectResponses()
+    {
+        $this->addAction('template_redirect', function () {
+            if (! $this->isSendingRedirectResponse()) {
+                return;
+            }
+
+            if ($this->sendsRedirectResponsesData['safe']) {
+                $cancelled = wp_safe_redirect(
+                    $this->sendsRedirectResponsesData['location'],
+                    $this->sendsRedirectResponsesData['status'],
+                    $this->sendsRedirectResponsesData['redirectBy']
+                );
+            } else {
+                $cancelled = wp_redirect(
+                    $this->sendsRedirectResponsesData['location'],
+                    $this->sendsRedirectResponsesData['status'],
+                    $this->sendsRedirectResponsesData['redirectBy']
+                );
+            }
+
+            if (! $cancelled) {
+                exit;
+            }
+        });
+
+        $this->addConflictCheck(function () {
+            if (! $this->isSendingRedirectResponse()) {
+                return;
+            }
+
+            if (
+                method_exists($this, 'isModifyingResponseHtmlTemplate')
+                && $this->isModifyingResponseHtmlTemplate()
+            ) {
+                return '@todo';
+            }
+
+            if (method_exists($this, 'isSendingJsonResponse') && $this->isSendingJsonResponse()) {
+                return '@todo';
+            }
+        });
+    }
+
+    protected function isSendingRedirectResponse(): bool
+    {
+        return is_string($this->sendsRedirectResponsesData['location'])
+            && '' !== $this->sendsRedirectResponsesData['location'];
+    }
+}

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -80,14 +80,21 @@ trait SendsRedirectResponses
             }
 
             if (
-                method_exists($this, 'isModifyingResponseHtmlTemplate')
-                && $this->isModifyingResponseHtmlTemplate()
+                method_exists($this, 'isModifyingResponseHtml')
+                && $this->isModifyingResponseHtml()
             ) {
-                return 'Cannot set redirect response and template response at the same time';
+                return 'Cannot send redirect response and modify response HTML at the same time';
+            }
+
+            if (
+                method_exists($this, 'isSendingDirectResponse')
+                && $this->isSendingDirectResponse()
+            ) {
+                return 'Cannot send redirect response and direct response at the same time';
             }
 
             if (method_exists($this, 'isSendingJsonResponse') && $this->isSendingJsonResponse()) {
-                return 'Cannot set redirect response and JSON response at the same time';
+                return 'Cannot send redirect response and JSON response at the same time';
             }
         });
     }

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 trait SendsRedirectResponses
 {
     protected array $sendsRedirectResponsesData = [
-        'location' => '',
+        'location' => null,
         'redirectBy' => 'WordPress',
         'safe' => true,
         'status' => 302,
@@ -109,7 +109,6 @@ trait SendsRedirectResponses
 
     protected function isSendingRedirectResponse(): bool
     {
-        return is_string($this->sendsRedirectResponsesData['location'])
-            && '' !== $this->sendsRedirectResponsesData['location'];
+        return is_string($this->sendsRedirectResponsesData['location']);
     }
 }

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -6,7 +6,7 @@ namespace ToyWpRouting\Responder\Concerns;
 
 use InvalidArgumentException;
 
-// @todo Conflicts - headers contain x-redirect-by, status,
+// @todo Conflicts - headers contain x-redirect-by
 trait SendsRedirectResponses
 {
     protected array $sendsRedirectResponsesData = [
@@ -77,6 +77,14 @@ trait SendsRedirectResponses
         $this->addConflictCheck(function () {
             if (! $this->isSendingRedirectResponse()) {
                 return;
+            }
+
+            if (
+                method_exists($this, 'isModifyingResponseStatus')
+                && $this->isModifyingResponseStatus()
+            ) {
+                return 'Cannot set status code on redirect response via "withStatusCode" method'
+                    . ' - must use "withRedirectStatusCode" method';
             }
 
             if (

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -83,11 +83,11 @@ trait SendsRedirectResponses
                 method_exists($this, 'isModifyingResponseHtmlTemplate')
                 && $this->isModifyingResponseHtmlTemplate()
             ) {
-                return '@todo';
+                return 'Cannot set redirect response and template response at the same time';
             }
 
             if (method_exists($this, 'isSendingJsonResponse') && $this->isSendingJsonResponse()) {
-                return '@todo';
+                return 'Cannot set redirect response and JSON response at the same time';
             }
         });
     }

--- a/src/Responder/Concerns/SendsRedirectResponses.php
+++ b/src/Responder/Concerns/SendsRedirectResponses.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting\Responder;
+namespace ToyWpRouting\Responder\Concerns;
 
 use InvalidArgumentException;
 

--- a/src/Responder/HookDrivenResponder.php
+++ b/src/Responder/HookDrivenResponder.php
@@ -42,7 +42,7 @@ class HookDrivenResponder implements ResponderInterface
     {
         $this->actions = [];
 
-        foreach ($actions as $tag => $$actionList) {
+        foreach ($actions as $tag => $actionList) {
             foreach ($actionList as [$callback, $priority]) {
                 $this->addAction($tag, $callback, $priority);
             }

--- a/src/Responder/HookDrivenResponder.php
+++ b/src/Responder/HookDrivenResponder.php
@@ -109,7 +109,7 @@ class HookDrivenResponder implements ResponderInterface
             $method = 'initialize' . Support::classBaseName($trait);
 
             if (method_exists($this, $method)) {
-                ($this->{$method})();
+                $this->{$method}();
             }
         }
     }

--- a/src/Responder/HookDrivenResponder.php
+++ b/src/Responder/HookDrivenResponder.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use RuntimeException;
+use ToyWpRouting\Support;
+
+class HookDrivenResponder implements ResponderInterface
+{
+    protected array $actions = [];
+    protected array $conflictChecks = [];
+    protected array $filters = [];
+
+    public function respond(): void
+    {
+        $this->initializeTraits();
+        $this->checkForConflicts();
+
+        foreach ($this->actions as $tag => $actionList) {
+            foreach ($actionList as [$callback, $priority]) {
+                add_action($tag, $callback, $priority, 999);
+            }
+        }
+
+        foreach ($this->filters as $tag => $filterList) {
+            foreach ($filterList as [$callback, $priority]) {
+                add_filter($tag, $callback, $priority, 999);
+            }
+        }
+    }
+
+    public function withAction(string $tag, callable $callback, int $priority = 10): self
+    {
+        $this->addAction($tag, $callback, $priority);
+
+        return $this;
+    }
+
+    public function withActions(array $actions): self
+    {
+        $this->actions = [];
+
+        foreach ($actions as $tag => $$actionList) {
+            foreach ($actionList as [$callback, $priority]) {
+                $this->addAction($tag, $callback, $priority);
+            }
+        }
+
+        return $this;
+    }
+
+    public function withFilter(string $tag, callable $callback, int $priority = 10): self
+    {
+        $this->addFilter($tag, $callback, $priority);
+
+        return $this;
+    }
+
+    public function withFilters(array $filters): self
+    {
+        $this->filters = [];
+
+        foreach ($filters as $tag => $filterList) {
+            foreach ($filterList as [$callback, $priority]) {
+                $this->addFilter($tag, $callback, $priority);
+            }
+        }
+
+        return $this;
+    }
+
+    protected function addAction(string $tag, callable $callback, int $priority = 10): void
+    {
+        if (! array_key_exists($tag, $this->actions)) {
+            $this->actions[$tag] = [];
+        }
+
+        $this->actions[$tag][] = [$callback, $priority];
+    }
+
+    protected function addConflictCheck(callable $callback): void
+    {
+        $this->conflictChecks[] = $callback;
+    }
+
+    protected function addFilter(string $tag, callable $callback, int $priority = 10): void
+    {
+        if (! array_key_exists($tag, $this->filters)) {
+            $this->filters[$tag] = [];
+        }
+
+        $this->filters[$tag][] = [$callback, $priority];
+    }
+
+    protected function checkForConflicts(): void
+    {
+        foreach ($this->conflictChecks as $callback) {
+            if (is_string($message = $callback())) {
+                throw new RuntimeException($message);
+            }
+        }
+    }
+
+    protected function initializeTraits(): void
+    {
+        foreach (Support::classUsesRecursive(static::class) as $trait) {
+            $method = 'initialize' . Support::classBaseName($trait);
+
+            if (method_exists($this, $method)) {
+                ($this->{$method})();
+            }
+        }
+    }
+}

--- a/src/Responder/JsonResponder.php
+++ b/src/Responder/JsonResponder.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace ToyWpRouting\Responder;
 
+use ToyWpRouting\Responder\Concerns\ModifiesResponseHeaders;
+use ToyWpRouting\Responder\Concerns\SendsJsonResponses;
+
 class JsonResponder extends HookDrivenResponder
 {
     use ModifiesResponseHeaders;

--- a/src/Responder/JsonResponder.php
+++ b/src/Responder/JsonResponder.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+class JsonResponder extends HookDrivenResponder
+{
+    use ModifiesResponseHeaders;
+    use SendsJsonResponses;
+
+    public function __construct(array $data, int $statusCode = 200, int $options = 0)
+    {
+        $this->withJsonData($data)
+            ->withJsonStatusCode($statusCode)
+            ->withJsonOptions($options);
+    }
+}

--- a/src/Responder/MethodNotAllowedResponder.php
+++ b/src/Responder/MethodNotAllowedResponder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting;
+namespace ToyWpRouting\Responder;
 
 use WP_Query;
 
@@ -62,7 +62,7 @@ class MethodNotAllowedResponder implements ResponderInterface
 
         // Alternatively we might want to just fall back to the theme index template...
         if (! \is_string($errorTemplate) || '' === $errorTemplate) {
-            $errorTemplate = dirname(__DIR__) . '/templates/405.php';
+            $errorTemplate = realpath(__DIR__ . '/../../templates/405.php');
         }
 
         return $errorTemplate;

--- a/src/Responder/QueryResponder.php
+++ b/src/Responder/QueryResponder.php
@@ -10,7 +10,6 @@ class QueryResponder extends HookDrivenResponder
 {
     use ModifiesWpParameters;
 
-    // @todo Should overwrite be true by default?
     public function __construct(array $queryVariables, bool $overwriteExisting = false)
     {
         $this->withPreLoopQueryVariables($queryVariables);

--- a/src/Responder/QueryResponder.php
+++ b/src/Responder/QueryResponder.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+use ToyWpRouting\Responder\Concerns\ModifiesWpParameters;
+
+class QueryResponder extends HookDrivenResponder
+{
+    use ModifiesWpParameters;
+
+    // @todo Should overwrite be true by default?
+    public function __construct(array $queryVariables, bool $overwriteExisting = false)
+    {
+        $this->withPreLoopQueryVariables($queryVariables);
+
+        if ($overwriteExisting) {
+            $this->withExistingPreLoopQueryVariablesOverwritten();
+        }
+    }
+}

--- a/src/Responder/QueryResponder.php
+++ b/src/Responder/QueryResponder.php
@@ -12,10 +12,10 @@ class QueryResponder extends HookDrivenResponder
 
     public function __construct(array $queryVariables, bool $overwriteExisting = false)
     {
-        $this->withPreLoopQueryVariables($queryVariables);
+        $this->withRequestVariables($queryVariables);
 
         if ($overwriteExisting) {
-            $this->withExistingPreLoopQueryVariablesOverwritten();
+            $this->withExistingRequestVariablesOverwritten();
         }
     }
 }

--- a/src/Responder/RedirectResponder.php
+++ b/src/Responder/RedirectResponder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+class RedirectResponder extends HookDrivenResponder
+{
+    use ModifiesResponseHeaders;
+    use SendsRedirectResponses;
+
+    public function __construct(
+        string $location,
+        int $statusCode = 302,
+        string $redirectByHeader = 'WordPress',
+        bool $safe = true
+    ) {
+        $this->withRedirectLocation($location)
+            ->withRedirectStatusCode($statusCode)
+            ->withRedirectByHeader($redirectByHeader);
+
+        if (! $safe) {
+            $this->withUnsafeRedirectsAllowed();
+        }
+    }
+}

--- a/src/Responder/RedirectResponder.php
+++ b/src/Responder/RedirectResponder.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace ToyWpRouting\Responder;
 
+use ToyWpRouting\Responder\Concerns\ModifiesResponseHeaders;
+use ToyWpRouting\Responder\Concerns\SendsRedirectResponses;
+
 class RedirectResponder extends HookDrivenResponder
 {
     use ModifiesResponseHeaders;

--- a/src/Responder/ResponderInterface.php
+++ b/src/Responder/ResponderInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ToyWpRouting;
+namespace ToyWpRouting\Responder;
 
 interface ResponderInterface
 {

--- a/src/Responder/TemplateResponder.php
+++ b/src/Responder/TemplateResponder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ToyWpRouting\Responder;
 
+use ToyWpRouting\Responder\Concerns\ModifiesResponseHtml;
+
 // @todo modifies wp? modifies wp query?
 class TemplateResponder extends HookDrivenResponder
 {

--- a/src/Responder/TemplateResponder.php
+++ b/src/Responder/TemplateResponder.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace ToyWpRouting\Responder;
 
+use ToyWpRouting\Responder\Concerns\ModifiesResponseHeaders;
 use ToyWpRouting\Responder\Concerns\ModifiesResponseHtml;
+use ToyWpRouting\Responder\Concerns\ModifiesWpParameters;
+use ToyWpRouting\Responder\Concerns\ModifiesWpQueryParameters;
 
-// @todo modifies wp? modifies wp query?
 class TemplateResponder extends HookDrivenResponder
 {
+    use ModifiesResponseHeaders;
     use ModifiesResponseHtml;
+    use ModifiesWpParameters;
+    use ModifiesWpQueryParameters;
 
     public function __construct(string $templatePath)
     {

--- a/src/Responder/TemplateResponder.php
+++ b/src/Responder/TemplateResponder.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ToyWpRouting\Responder;
+
+// @todo modifies wp? modifies wp query?
+class TemplateResponder extends HookDrivenResponder
+{
+    use ModifiesResponseHtml;
+
+    public function __construct(string $templatePath)
+    {
+        $this->withTemplate($templatePath);
+    }
+}

--- a/src/Rewrite.php
+++ b/src/Rewrite.php
@@ -41,7 +41,7 @@ class Rewrite implements RewriteInterface
     public function __construct(array $methods, array $rules, $handler, $isActiveCallback = null)
     {
         if (! Support::isValidMethodsList($methods)) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException('Invalid rewrite methods list');
         }
 
         $this->methods = $methods;

--- a/src/Route.php
+++ b/src/Route.php
@@ -39,7 +39,7 @@ class Route
     public function __construct(array $methods, string $route, $handler)
     {
         if (! Support::isValidMethodsList($methods)) {
-            throw new InvalidArgumentException('@todo');
+            throw new InvalidArgumentException('Invalid route methods list');
         }
 
         $this->methods = $methods;

--- a/src/Support.php
+++ b/src/Support.php
@@ -50,6 +50,21 @@ class Support
         ));
     }
 
+    public static function classBaseName(string $fqcn): string
+    {
+        return basename(str_replace('\\', '/', $fqcn));
+    }
+    public static function classUsesRecursive(string $class): array
+    {
+        $traits = [];
+
+        foreach (array_reverse(class_parents($class)) + [$class => $class] as $class) {
+            $traits += static::traitUsesRecursive($class);
+        }
+
+        return $traits;
+    }
+
     public static function isValidMethodsList(array $methods): bool
     {
         if ([] === $methods) {
@@ -71,5 +86,16 @@ class Support
         parse_str($query, $result);
 
         return $result;
+    }
+
+    public static function traitUsesRecursive(string $class): array
+    {
+        $traits = class_uses($class) ?: [];
+
+        foreach ($traits as $trait) {
+            $traits += static::traitUsesRecursive($trait);
+        }
+
+        return $traits;
     }
 }

--- a/tests/MethodNotAllowedResponderTest.php
+++ b/tests/MethodNotAllowedResponderTest.php
@@ -7,7 +7,7 @@ namespace ToyWpRouting\Tests;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
-use ToyWpRouting\MethodNotAllowedResponder;
+use ToyWpRouting\Responder\MethodNotAllowedResponder;
 
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\setUp;

--- a/tests/OrchestratorTest.php
+++ b/tests/OrchestratorTest.php
@@ -6,10 +6,10 @@ namespace ToyWpRouting\Tests;
 
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use ToyWpRouting\MethodNotAllowedResponder;
 use ToyWpRouting\Orchestrator;
 use ToyWpRouting\RequestContext;
-use ToyWpRouting\ResponderInterface;
+use ToyWpRouting\Responder\MethodNotAllowedResponder;
+use ToyWpRouting\Responder\ResponderInterface;
 use ToyWpRouting\RewriteCollection;
 
 use function Brain\Monkey\setUp;

--- a/tests/Responder/HookDrivenResponderTest.php
+++ b/tests/Responder/HookDrivenResponderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace ToyWpRouting\Tests\Responder;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ToyWpRouting\Responder\HookDrivenResponder;
+
+// @todo bring in brain/monkey
+class HookDrivenResponderTest extends TestCase
+{
+    public function testInitializeTraits()
+    {
+        $responder = new class extends HookDrivenResponder
+        {
+            use One;
+            use Two;
+        };
+        $responder->respond();
+
+        $this->assertSame(1, $responder->oneCount);
+        $this->assertSame(1, $responder->twoCount);
+    }
+
+    public function testCheckForConflicts()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('test-conflict-message');
+
+        $responder = new class extends HookDrivenResponder
+        {
+            use Two;
+            use Three;
+        };
+        $responder->respond();
+    }
+}
+
+trait One
+{
+    public $oneCount = 0;
+
+    protected function initializeOne(): void
+    {
+        $this->oneCount++;
+    }
+}
+
+trait Two
+{
+    public $twoCount = 0;
+
+    protected function initializeTwo(): void
+    {
+        $this->twoCount++;
+    }
+}
+
+trait Three
+{
+    protected function initializeThree(): void
+    {
+        $this->addConflictCheck(function () {
+            if (property_exists($this, 'twoCount')) {
+                return 'test-conflict-message';
+            }
+        });
+    }
+}

--- a/tests/Responder/HookDrivenResponderTest.php
+++ b/tests/Responder/HookDrivenResponderTest.php
@@ -24,6 +24,18 @@ class HookDrivenResponderTest extends TestCase
 
     public function testCheckForConflicts()
     {
+        $responder = new class extends HookDrivenResponder
+        {
+            use One;
+            use Three;
+        };
+        $responder->respond();
+
+        $this->assertSame(1, $responder->conflictCount);
+    }
+
+    public function testCheckForConflictsThrowsFirstConflict()
+    {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('test-conflict-message');
 
@@ -39,10 +51,18 @@ class HookDrivenResponderTest extends TestCase
 trait One
 {
     public $oneCount = 0;
+    public $conflictCount = 0;
 
     protected function initializeOne(): void
     {
         $this->oneCount++;
+
+        $this->addConflictCheck(function () {
+            $this->conflictCount++;
+
+            // As long as we don't return a string we shouldn't get any errors.
+            return;
+        });
     }
 }
 

--- a/tests/Responder/HookDrivenResponderTest.php
+++ b/tests/Responder/HookDrivenResponderTest.php
@@ -11,23 +11,9 @@ use ToyWpRouting\Responder\HookDrivenResponder;
 // @todo bring in brain/monkey
 class HookDrivenResponderTest extends TestCase
 {
-    public function testInitializeTraits()
-    {
-        $responder = new class extends HookDrivenResponder
-        {
-            use One;
-            use Two;
-        };
-        $responder->respond();
-
-        $this->assertSame(1, $responder->oneCount);
-        $this->assertSame(1, $responder->twoCount);
-    }
-
     public function testCheckForConflicts()
     {
-        $responder = new class extends HookDrivenResponder
-        {
+        $responder = new class () extends HookDrivenResponder {
             use One;
             use Three;
         };
@@ -41,19 +27,30 @@ class HookDrivenResponderTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('test-conflict-message');
 
-        $responder = new class extends HookDrivenResponder
-        {
+        $responder = new class () extends HookDrivenResponder {
             use Two;
             use Three;
         };
         $responder->respond();
     }
+
+    public function testInitializeTraits()
+    {
+        $responder = new class () extends HookDrivenResponder {
+            use One;
+            use Two;
+        };
+        $responder->respond();
+
+        $this->assertSame(1, $responder->oneCount);
+        $this->assertSame(1, $responder->twoCount);
+    }
 }
 
 trait One
 {
-    public $oneCount = 0;
     public $conflictCount = 0;
+    public $oneCount = 0;
 
     protected function initializeOne(): void
     {

--- a/tests/Responder/HookDrivenResponderTest.php
+++ b/tests/Responder/HookDrivenResponderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace ToyWpRouting\Tests\Responder;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/RewriteTest.php
+++ b/tests/RewriteTest.php
@@ -95,7 +95,7 @@ class RewriteTest extends TestCase
     public function testWithInvalidMethods()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('@todo');
+        $this->expectExceptionMessage('Invalid rewrite methods list');
 
         new Rewrite(
             ['GET', 'BADMETHOD'],

--- a/tests/SupportTest.php
+++ b/tests/SupportTest.php
@@ -69,6 +69,27 @@ class SupportTest extends TestCase
         );
     }
 
+    public function testClassBaseName()
+    {
+        $this->assertSame('Baz', Support::classBaseName('Baz'));
+        $this->assertSame('Baz', Support::classBaseName('Bar\\Baz'));
+        $this->assertSame('Baz', Support::classBaseName('Foo\\Bar\\Baz'));
+    }
+
+    public function testClassUsesRecursive()
+    {
+        $this->assertSame([
+            TraitTwo::class => TraitTwo::class,
+            TraitOne::class => TraitOne::class,
+        ], Support::classUsesRecursive(ClassTwo::class));
+
+        $this->assertSame([
+            TraitTwo::class => TraitTwo::class,
+            TraitOne::class => TraitOne::class,
+            TraitThree::class => TraitThree::class,
+        ], Support::classUsesRecursive(ClassThree::class));
+    }
+
     public function testIsValidMethodsList()
     {
         // False for empty array.
@@ -115,4 +136,34 @@ class SupportTest extends TestCase
             'five' => 'six',
         ], Support::parseQuery($query));
     }
+}
+
+trait TraitOne
+{
+    //
+}
+
+trait TraitTwo
+{
+    use TraitOne;
+}
+
+trait TraitThree
+{
+    //
+}
+
+class ClassOne
+{
+    use TraitTwo;
+}
+
+class ClassTwo extends ClassOne
+{
+    //
+}
+
+class ClassThree extends ClassTwo
+{
+    use TraitThree;
 }


### PR DESCRIPTION
First pass at common responders implementations.

Includes JSON responder, query responder, redirect responder, and template responder.

I don't feel great about the way we are using the traits in `ToyWpRouting\Responder\Concerns` but it was the best of the bad ideas I came up with for the type of code reuse I was looking for. Maybe this can be a problem for future me...

If the traits are kept, they could definitely use some tests.

Also should consider whether responders should be made immutable or whether their `with*` methods should be renamed given that with is typically a prefix used for methods on immutable classes.